### PR TITLE
워치 정보 전송 오류 해결

### DIFF
--- a/DDanDDan/Entity/Error/NetworkError.swift
+++ b/DDanDDan/Entity/Error/NetworkError.swift
@@ -12,7 +12,7 @@ public enum NetworkError: Error {
     case invalidResponse
     case failToDecode(String)
     case dataNil
-    case serverError(Int)
+    case serverError(Int, String)
     case requestFailed(String)
     case encodingError
     public var description: String {
@@ -21,9 +21,16 @@ public enum NetworkError: Error {
         case .dataNil: return "데이터가 없습니다."
         case .failToDecode(let message): return "디코딩 에러 \(message)"
         case .invalidResponse: return "유효하지 않은 응답 값입니다."
-        case .serverError(let code): return "서버 에러 \(code)"
+        case .serverError(let code, let message): return "서버 에러: \(code), \(message)"
         case .requestFailed(let message): return "서버 요청 실패 \(message)"
         case .encodingError: return "인코딩 실패"
         }
     }
+}
+
+
+struct ServerErrorResponse: Decodable {
+    let code: String
+    let message: String
+    let data: String?
 }

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -105,7 +105,7 @@ struct HomeView: View {
             }
             .onChange(of: viewModel.isGoalMet) { newValue in
                 if newValue {
-                    coordinator.push( to: .successThreeDay(totalKcal: 1000))
+                    coordinator.push( to: .successThreeDay(totalKcal: viewModel.threeDaysTotalKcal))
                 }
             }
             .onReceive(coordinator.$shouldUpdateHomeView) { shouldUpdate in

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -79,16 +79,6 @@ struct HomeView: View {
                     viewModel.showRandomBubble(type: .success)
                 }
             }
-            TransparentOverlayView(isPresented: $viewModel.isDailyGoalMet) {
-                DialogView(
-                    show: $viewModel.isDailyGoalMet,
-                    title: "목표 칼로리를 달성했어요!",
-                    description: "먹이 3개를 받으세요.",
-                    rightButtonTitle: "확인",
-                    leftButtonTitle: "취소") {
-                        viewModel.homePetModel.feedCount += 3
-                    }
-            }
             .onChange(of: viewModel.isLevelUp) { newLevel in
                 if newLevel {
                     coordinator.push( to: .upgradePet(
@@ -112,8 +102,9 @@ struct HomeView: View {
                 if shouldUpdate {
                     Task {
                         await viewModel.fetchHomeInfo()
+                        
+                        coordinator.shouldUpdateHomeView = false
                     }
-                    coordinator.shouldUpdateHomeView = false
                 }
             }
 

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -177,12 +177,10 @@ final class HomeViewModel: ObservableObject {
     private func handleKcalUpdate(newKcal: Int) {
         let kcalDifference = (newKcal % 100) - (previousKcal % 100)
         
-        if kcalDifference >= 1 {
             Task {
                 await saveCurrentKcal(currentKcal: newKcal)
             }
             previousKcal = newKcal
-        }
         
         if newKcal >= homePetModel.goalKcal {
             DispatchQueue.main.async { [weak self] in
@@ -205,8 +203,12 @@ final class HomeViewModel: ObservableObject {
                 
                 /// 현재 먹이 개수와 다르면 먹이 얻기
                 if self.homePetModel.feedCount != dailyInfo.user.foodQuantity {
-                    self.earnFood = dailyInfo.user.foodQuantity - self.homePetModel.feedCount
-                    self.isPresentEarnFood = true
+                    if dailyInfo.user.foodQuantity - self.homePetModel.feedCount == 3 {
+                        self.isDailyGoalMet = true
+                    } else {
+                        self.earnFood = dailyInfo.user.foodQuantity - self.homePetModel.feedCount
+                        self.isPresentEarnFood = true
+                    }
                 }
                 
                 if self.homePetModel.toyCount != dailyInfo.user.toyQuantity {
@@ -216,12 +218,6 @@ final class HomeViewModel: ObservableObject {
                             self.threeDaysTotalKcal = Int(totalKcal)
                             self.isGoalMet = true
                         }
-                    }
-                }
-                
-                if currentKcal >= dailyInfo.user.purposeCalorie {
-                    DispatchQueue.main.async { [weak self] in
-                        self?.isDailyGoalMet = true
                     }
                 }
                 

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -212,8 +212,10 @@ final class HomeViewModel: ObservableObject {
                 if self.homePetModel.toyCount != dailyInfo.user.toyQuantity {
                     healthKitManager.readThreeDaysTotalKcal { [weak self] totalKcal in
                         guard let self else { return }
-                        self.threeDaysTotalKcal = Int(totalKcal)
-                        self.isGoalMet = true
+                        DispatchQueue.main.async {
+                            self.threeDaysTotalKcal = Int(totalKcal)
+                            self.isGoalMet = true
+                        }
                     }
                 }
                 

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -85,17 +85,14 @@ final class HomeViewModel: ObservableObject {
                 toyCount: userInfo.toyQuantity
             )
             
-            let goalKcal = userInfo.purposeCalorie
-            let petType = petInfo.mainPet.type.rawValue
-            let level = petInfo.mainPet.level
-            
-            let message = ["purposeKcal": goalKcal]
-            let petTypeMessage = ["petType": petType]
-            let levelMessage = ["level" : level]
-            
-            WatchConnectivityManager.shared.sendMessage(message: message)
-            WatchConnectivityManager.shared.sendMessage(message: petTypeMessage)
-            WatchConnectivityManager.shared.sendMessage(message: levelMessage)
+            let info: [String: Any] = [
+                "purposeKcal": userInfo.purposeCalorie,
+                "petType": petInfo.mainPet.type.rawValue,
+                "level": petInfo.mainPet.level
+            ]
+
+            WatchConnectivityManager.shared.transferUserInfo(info: info)
+
         }
     }
     

--- a/DDanDDan/Presenter/Home/Views/Challenge/NewPetView.swift
+++ b/DDanDDan/Presenter/Home/Views/Challenge/NewPetView.swift
@@ -26,8 +26,8 @@ struct NewPetView: View {
                 GreenButton(action: {
                     Task {
                         await viewModel.createRandomPet()
+                        coordinator.pop()
                     }
-                    coordinator.pop()
                 }, title: "시작하기", disabled: .constant(false))
                 .padding(.bottom, 44)
             }
@@ -39,7 +39,7 @@ struct NewPetView: View {
     var imageView: some View {
         ZStack {
             Image(.pangGraphics)
-            Image(.eggBlue)
+            Image(.pinkEgg)
                 .offset(y: 18)
         }
     }

--- a/DDanDDan/Presenter/Login/LoginViewModel.swift
+++ b/DDanDDan/Presenter/Login/LoginViewModel.swift
@@ -13,7 +13,7 @@ public class LoginViewModel: NSObject, ObservableObject {
     private let repository: LoginRepositoryProtocol
     let appCoordinator: AppCoordinator
     
-    @Published var toastMessage: String = "로그인에 실패했습니다. 잠시후 다시 실행해주세요"
+    @Published var toastMessage: String = "로그인에 실패했습니다."
     @Published var showToast: Bool = false
     
     init(repository: LoginRepositoryProtocol, appCoordinator: AppCoordinator) {
@@ -68,6 +68,12 @@ public class LoginViewModel: NSObject, ObservableObject {
                 }
             case .failure(let error):
                 DispatchQueue.main.async { [weak self] in
+                    switch error {
+                    case .serverError(let code, let message):
+                        self?.toastMessage = "로그인에 실패했습니다: \(message)"
+                    case .dataNil, .encodingError, .failToDecode, .invalidResponse, .requestFailed, .urlError:
+                        break
+                    }
                     self?.showToastMessage()
                 }
                 print(error)

--- a/DDanDDan/Presenter/Login/LoginViewModel.swift
+++ b/DDanDDan/Presenter/Login/LoginViewModel.swift
@@ -63,6 +63,7 @@ public class LoginViewModel: NSObject, ObservableObject {
             case .success(let loginData):
                 await UserManager.shared.login(loginData: loginData)
                 DispatchQueue.main.async { [weak self] in
+                    self?.appCoordinator.triggerHomeUpdate()
                     self?.appCoordinator.determineRootView()
                 }
             case .failure(let error):

--- a/DDanDDan/Presenter/Login/SignUp/SignUpSuccessView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpSuccessView.swift
@@ -31,6 +31,7 @@ struct SignUpSuccessView: View {
                 GreenButton(action: {
                     Task {
                         await viewModel.login()
+                        coordinator.triggerHomeUpdate()
                         coordinator.setRoot(to: .home)
                     }
                 }, title: "시작하기", disabled: .constant(false))

--- a/DDanDDan/Presenter/Login/SignUp/SignUpTermView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpTermView.swift
@@ -82,7 +82,7 @@ public struct SignUpTermView: View {
             } 
             .navigationDestination(for: SignUpPath.self) { path in
                 switch path {
-                case .term: SignUpTermView(viewModel: SignUpViewModel(repository: SignUpRepository()), coordinator: coordinator)
+                case .term: SignUpTermView(viewModel: viewModel, coordinator: coordinator)
                 case .egg: SignUpEggView(viewModel: viewModel, coordinator: coordinator)
                 case .nickname: SignUpNicknameView(viewModel: viewModel, coordinator: coordinator)
                 case .calorie: SignUpCalorieView(viewModel: viewModel, coordinator: coordinator)

--- a/DDanDDan/Presenter/Setting/UpdateCalorie/UpdateCalorieView.swift
+++ b/DDanDDan/Presenter/Setting/UpdateCalorie/UpdateCalorieView.swift
@@ -50,6 +50,7 @@ struct UpdateCalorieView: View {
                 GreenButton(action: {
                     Task {
                         if await viewModel.update() {
+                            coordinator.triggerHomeUpdate()
                             coordinator.pop()
                         }
                     }

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -36,17 +36,13 @@ final class SplashViewModel: ObservableObject {
                 UserDefaultValue.purposeKcal = userData.purposeCalorie
                 UserDefaultValue.level = petData.mainPet.level
                 
-                let goalKcal = userData.purposeCalorie
-                let petType = petData.mainPet.type.rawValue
-                let level = petData.mainPet.level
+                let info: [String: Any] = [
+                    "purposeKcal": userData.purposeCalorie,
+                    "petType": petData.mainPet.type.rawValue,
+                    "level": petData.mainPet.level
+                ]
                 
-                let message = ["purposeKcal": goalKcal]
-                let petTypeMessage = ["petType": petType]
-                let levelMessage = ["level" : level]
-                
-                WatchConnectivityManager.shared.sendMessage(message: message)
-                WatchConnectivityManager.shared.sendMessage(message: petTypeMessage)
-                WatchConnectivityManager.shared.sendMessage(message: levelMessage)
+                WatchConnectivityManager.shared.transferUserInfo(info: info)
                 
                 self.coordinator.setRoot(to: .home)
             }

--- a/DDanDDan/Util/WatchConnectivityManager.swift
+++ b/DDanDDan/Util/WatchConnectivityManager.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// WatchConnectivity 관리하는 클래스, iOS - Watch 간 데이터 통신 담당
 final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
     static let shared = WatchConnectivityManager()
-
+    
     // MARK: - Init
     
     override private init() {
@@ -29,16 +29,15 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
     /// - Parameters
     /// `message`: 전송할 키값과 데이터
     func sendMessage(message: [String: Any]) {
-            print("Sending message to Watch")
-            if WCSession.default.isReachable {
-                WCSession.default.sendMessage(message, replyHandler: { response in
-                    print("Message sent successfully: \(response)")
-                }, errorHandler: { error in
+        print("Sending message to Watch")
+        if WCSession.default.isReachable {
+            WCSession.default.sendMessage(message, replyHandler: { response in
+                print("Message sent successfully: \(response)")
+            }, errorHandler: { error in
                 print("Error sending message: \(error.localizedDescription)")
-                })
-            } else {
-                print("Watch is not reachable")
-            }
+            })
+        } else {
+            print("Watch is not reachable")
         }
     }
     
@@ -56,12 +55,12 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
     
     /// WCSessionDelegate 프로토콜 메서드 - 세션 활성화 완료 시 호출
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: (any Error)?) {
-            print("WCSession activation completed with state: \(activationState)")
-            
-            // 세션이 활성화된 후 펫 정보를 보냄
-            if activationState == .activated {
-                // 여기에 펫 정보를 보내는 코드 추가
-                let goalKcal = UserDefaultValue.purposeKcal
+        print("WCSession activation completed with state: \(activationState)")
+        
+        // 세션이 활성화된 후 펫 정보를 보냄
+        if activationState == .activated {
+            // 여기에 펫 정보를 보내는 코드 추가
+            let goalKcal = UserDefaultValue.purposeKcal
             let petType = UserDefaultValue.petType
             let level = UserDefaultValue.level
             

--- a/DDanDDan/Util/WatchConnectivityManager.swift
+++ b/DDanDDan/Util/WatchConnectivityManager.swift
@@ -29,17 +29,28 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
     /// - Parameters
     /// `message`: 전송할 키값과 데이터
     func sendMessage(message: [String: Any]) {
-        print("Sending message to Watch")
-        if WCSession.default.isReachable {
-            WCSession.default.sendMessage(message, replyHandler: { response in
-                print("Message sent successfully: \(response)")
-            }, errorHandler: { error in
+            print("Sending message to Watch")
+            if WCSession.default.isReachable {
+                WCSession.default.sendMessage(message, replyHandler: { response in
+                    print("Message sent successfully: \(response)")
+                }, errorHandler: { error in
                 print("Error sending message: \(error.localizedDescription)")
-            })
-        } else {
-            print("Watch is not reachable")
+                })
+            } else {
+                print("Watch is not reachable")
+            }
         }
     }
+    
+    func transferUserInfo(info: [String: Any]) {
+        if WCSession.default.activationState == .activated {
+            WCSession.default.transferUserInfo(info)
+            print("User info transferred: \(info)")
+        } else {
+            print("WCSession is not activated")
+        }
+    }
+    
     
     // MARK: - 필수 구현 메서드 및 Delegate 메서드
     
@@ -51,19 +62,19 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
             if activationState == .activated {
                 // 여기에 펫 정보를 보내는 코드 추가
                 let goalKcal = UserDefaultValue.purposeKcal
-                let petType = UserDefaultValue.petType
-                let level = UserDefaultValue.level
-                
-                let message = ["purposeKcal": goalKcal]
-                let petTypeMessage = ["petType": petType]
-                let levelMessage = ["level" : level]
-                
-                sendMessage(message: message)
-                sendMessage(message: petTypeMessage)
-                sendMessage(message: levelMessage)
-            }
+            let petType = UserDefaultValue.petType
+            let level = UserDefaultValue.level
+            
+            let setting: [String : Any] = [
+                "purposeKcal": goalKcal,
+                "petType": petType,
+                "level" : level
+            ]
+            
+            self.transferUserInfo(info: setting)
         }
-        
+    }
+    
     
     /// 세션 비활성화되었을 때 호출
     func sessionDidBecomeInactive(_ session: WCSession) {    }

--- a/DdanDdan_Watch Watch App/DdanDdan_WatchApp.swift
+++ b/DdanDdan_Watch Watch App/DdanDdan_WatchApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @main
 struct DdanDdan_Watch_Watch_AppApp: App {
     private let wcSession = WatchConnectivityManager.shared
+    
     var body: some Scene {
         WindowGroup {
             ContentView(viewModel: WatchViewModel())

--- a/DdanDdan_Watch Watch App/Util/WatchConnectivityManager.swift
+++ b/DdanDdan_Watch Watch App/Util/WatchConnectivityManager.swift
@@ -12,8 +12,10 @@ import SwiftUI
 class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
     static let shared = WatchConnectivityManager()
     
-    @Published var watchPet: WatchPetModel?
-
+    @Published var purposeKcal: Double = 0.0
+    @Published var petType: String = ""
+    @Published var level: Int = 0
+    
     override private init() {
         super.init()
         if WCSession.isSupported() {
@@ -21,24 +23,30 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
             WCSession.default.activate()
         }
     }
-
+    
     // MARK: - 필수 구현 메서드 및 Delegate 메서드
     
     /// 세션 활성화 완료 시 호출
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         print("WCSession activation completed with state: \(activationState)")
     }
-
+    
     /// 워치로 iPhone으로부터 메시지를 받았을 때 처리하는 메서드
-        func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
-            print("Received message: \(message)")
-            
-            if let purposrKcal = message["purposeKcal"] as? Double,
-               let petType = message["petType"] as? String,
-               let level = message["level"] as? Int {
-                DispatchQueue.main.async {
-                    self.watchPet = WatchPetModel(petType: PetType(rawValue: petType) ?? .pinkCat, goalKcal: Int(purposrKcal), level: level)
-                }
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {    }
+    
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
+        print("Received user info: \(userInfo)")
+        
+        DispatchQueue.main.async {
+            if let purposeKcal = userInfo["purposeKcal"] as? Double {
+                self.purposeKcal = purposeKcal
+            }
+            if let petType = userInfo["petType"] as? String {
+                self.petType = petType
+            }
+            if let level = userInfo["level"] as? Int {
+                self.level = level
             }
         }
+    }
 }

--- a/DdanDdan_Watch Watch App/View/ContentView.swift
+++ b/DdanDdan_Watch Watch App/View/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView: View {
         .ignoresSafeArea()
         .onAppear {
             HealthKitManager.shared.requestAuthorization { isGranted in
-                viewModel.fetchActiveEnergyFromHealthKit()
+                viewModel.observeHealthKitData()
             }
         }
         .onTapGesture {

--- a/DdanDdan_Watch Watch App/View/WatchViewModel.swift
+++ b/DdanDdan_Watch Watch App/View/WatchViewModel.swift
@@ -16,6 +16,8 @@ final class WatchViewModel: ObservableObject {
     @Published var currentKcalProgress: Double = 0.0
     @Published var viewConfig: (Image, Color)?
     @Published var showLoginAlert = false
+    
+    private let healthKitManager: HealthKitManager = .shared
     private let watchConnectivityManager: WatchConnectivityManager = .shared
     
     init(currentKcal: Int = 0) {
@@ -25,12 +27,13 @@ final class WatchViewModel: ObservableObject {
         updateProgress()
     }
     
-    /// HealthKit에서 활성 에너지(kcal) 받아와서 현재 칼로리, 도달률 계산
-    public func fetchActiveEnergyFromHealthKit() {
-        HealthKitManager.shared.readActiveEnergyBurned { [weak self] kcal in
+    
+    func observeHealthKitData() {
+        healthKitManager.observeActiveEnergyBurned { [weak self] newKcal in
+            guard let self = self else { return }
             DispatchQueue.main.async {
-                self?.currentKcal = Int(kcal)
-                self?.updateProgress()
+                self.currentKcal = Int(newKcal)
+                self.updateProgress()
             }
         }
     }


### PR DESCRIPTION
## PR Point
1. 워치 정보 전송 방식 변경
#### 기존 Watch 정보 전송의 문제점
- _워치와 IOS 앱이 모두 활성화 된 상태_에만 메세지 형식의 세션 전송 가능
- 전송되는 세션도 불안정. 

#### 변경된 방법
- 사용하고 있던 `sendMessage(:_)`는 실시간 정보 교환에 적합. 즉 iOS앱과 워치앱 사이에서 동시에 작동되어야 하는 기능들에 적합함. (워치가 활성화되어 있지 않으면 정보 전송 X)
- 칼로리 정보는 HealthKit을 이용해서 관리. 따로 실시간으로 업데이트 해줄 필요가 없음
- 현재 우리는 단순한 설정(메인 펫 정보, 목표 칼로리)만 전달하면 되기 때문에 실시간으로 통신되는 기능은 적합하지 않음
-> `transferUserInfo(:_)` 메서드를 이용하는 방식으로 변경. 백그라운드 통신이 가능하기 때문에 단순 세팅을 전송하기에 적합
- 워치 실기기 연결 이슈로,, 미리 TestFlight에 올려뒀습니다! 업데이트하면 확인 가능합니당 ~,~

2. 기타 수정 사항
- 로그인 오류 트래킹을 위한 로깅 추가 및 토스트 메시지 변경 (에러 객체 디코딩 과정 포함)
