### PR TITLE
토큰 만료 시 재발급 오류 해결

### DIFF
--- a/DDanDDan/Network/TokenInterceptor.swift
+++ b/DDanDDan/Network/TokenInterceptor.swift
@@ -11,7 +11,7 @@ import Alamofire
 
 public final class TokenInterceptor: Interceptor {
     
-    private let maxRetryCount = 1
+    private let maxRetryCount = 3
     private var retryCounts: [URLRequest: Int] = [:]
     
     public override func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping (RetryResult) -> Void) {

--- a/DDanDDan/Network/TokenInterceptor.swift
+++ b/DDanDDan/Network/TokenInterceptor.swift
@@ -11,10 +11,24 @@ import Alamofire
 
 public final class TokenInterceptor: Interceptor {
     
+    private let maxRetryCount = 1
+    private var retryCounts: [URLRequest: Int] = [:]
+    
     public override func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping (RetryResult) -> Void) {
         
         guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
             completion(.doNotRetryWithError(error))
+            return
+        }
+        
+        var currentRetryCount = retryCounts[request.request ?? URLRequest(url: URL(string: "about:blank")!)] ?? 0
+        
+        if currentRetryCount >= maxRetryCount {
+            print("🔻 최대 재시도 횟수 초과: 로그아웃 처리")
+            Task {
+                await UserManager.shared.logout()
+            }
+            completion(.doNotRetry)
             return
         }
         
@@ -24,9 +38,11 @@ public final class TokenInterceptor: Interceptor {
         Task {
             let result = await network.tokenReissue(refreshToken: refreshToken ?? "")
             if case .success(let reissueData) = result {
+                print("🔹 토큰 재발급 완료 API 재시도")
                 UserDefaultValue.acessToken = reissueData.accessToken
                 UserDefaultValue.refreshToken = reissueData.refreshToken
                 
+                retryCounts[request.request ?? URLRequest(url: URL(string: "about:blank")!)] = currentRetryCount + 1
                 completion(.retry)
             } else if case .failure(let failure) = result {
                 print("🔻 Retry Error 발생")

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -19,31 +19,29 @@ final class SplashViewModel: ObservableObject {
     }
     
     func performInitialSetup() async {
-        async let userInfo = homeRepository.getUserInfo()
-        async let petInfo = homeRepository.getMainPetInfo()
-        
         do {
-            let userData = try await unwrapResult(userInfo)
-            let petData = try await unwrapResult(petInfo)
-            
+            let userData = try await unwrapResult(homeRepository.getUserInfo())
+
             DispatchQueue.main.async {
                 self.coordinator.userInfo = userData
-                self.coordinator.petInfo = petData
-                
                 UserDefaultValue.userId = userData.id
+                UserDefaultValue.purposeKcal = userData.purposeCalorie
+            }
+
+            let petData = try await unwrapResult(homeRepository.getMainPetInfo())
+
+            DispatchQueue.main.async {
+                self.coordinator.petInfo = petData
                 UserDefaultValue.petType = petData.mainPet.type.rawValue
                 UserDefaultValue.petId = petData.mainPet.id
-                UserDefaultValue.purposeKcal = userData.purposeCalorie
                 UserDefaultValue.level = petData.mainPet.level
-                
+
                 let info: [String: Any] = [
                     "purposeKcal": userData.purposeCalorie,
                     "petType": petData.mainPet.type.rawValue,
                     "level": petData.mainPet.level
                 ]
-                
                 WatchConnectivityManager.shared.transferUserInfo(info: info)
-                
                 self.coordinator.setRoot(to: .home)
             }
         } catch {


### PR DESCRIPTION
## PR 요약
- 엑세스 토큰 만료 시 재시도 하는 로직이 무한 반복 되어, 만료되고 첫 시도에 스플래쉬에서 넘어가지 않는 오류를 발견했습니다. 
- 인터셉터의 재시도 횟수 제한 로직을 통해 무한 반복되지 않도록 조정했습니다. 
- 근본적으로 스플래쉬에서 API 호출을 비동기 처리해서 발생하는 문제로 생각하고 순차적으로 호출하도록 수정했습니다.
- 토큰 재발급 이후 토큰 교체가 잘 이뤄지고 있는지 확인 부탁드립니다! 