### PR TITLE
펫 보관함 버튼 비활성화

### DIFF
--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -417,7 +417,6 @@
 			isa = PBXGroup;
 			children = (
 				360E6B3D2CEDF8010059661E /* LevelUp */,
-				367A79692CDCAB560055771B /* Archive */,
 				367A79682CDCAB4D0055771B /* Challenge */,
 			);
 			path = Views;
@@ -688,6 +687,7 @@
 		F84B21C32C902270009FE6F3 /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				367A79692CDCAB560055771B /* Archive */,
 				F84B21C42C90227A009FE6F3 /* SettingView.swift */,
 				F80DF7372CB3DA1C004FF1F2 /* DeleteUser */,
 				F80DF7342CB384FB004FF1F2 /* SettingTerm */,

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -77,7 +77,7 @@ struct PetArchiveView: View {
                     } else {
                         viewModel.showToastMessage()
                     }
-                }, title: "선택 완료", disabled: false)
+                }, title: "선택 완료", disabled: viewModel.isButtonDisable)
                 .padding(.bottom, 44)
             }
             if viewModel.showToast {

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
@@ -10,7 +10,8 @@ import HealthKit
 
 final class PetArchiveViewModel: ObservableObject {
     private let homeRepository: HomeRepositoryProtocol
-    
+    private var firstSelectedIndex: Int? = nil
+
     @Published var petList: [Pet] = []
     @Published var selectedIndex: Int? = nil
     @Published var petId: String = ""
@@ -18,6 +19,10 @@ final class PetArchiveViewModel: ObservableObject {
     @Published var showToast = false
     @Published var gridItemCount: Int = 9
     
+    var isButtonDisable: Bool {
+        guard let firstSelectedIndex, let selectedIndex else { return true }
+        return firstSelectedIndex == selectedIndex
+    }
     
     init(repository: HomeRepositoryProtocol) {
         self.homeRepository = repository
@@ -64,6 +69,7 @@ final class PetArchiveViewModel: ObservableObject {
         selectedIndex = pets.firstIndex {
             $0.id == UserDefaultValue.petId
         }
+        firstSelectedIndex = selectedIndex
     }
     
    


### PR DESCRIPTION
- 펫 보관함 폴더 Setting 아래로 이동
- 펫 보관함 같은 펫인경우 선택 버튼 비활성화
- 토스트는 랭킹 이후 추가 예정