### PR TITLE
토큰 재발급 로직 및 뷰 업데이트 개선

### DIFF
--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		369F16F52D8707E50039ED3A /* RankRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369F16F42D8707E50039ED3A /* RankRepository.swift */; };
 		369F16F92D99A3860039ED3A /* CustomScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369F16F82D99A3850039ED3A /* CustomScrollView.swift */; };
 		36A9D6F02DE5E41800A9169A /* SwipeBackEnabledModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A9D6EF2DE5E41800A9169A /* SwipeBackEnabledModifier.swift */; };
+		36A9D7652DF3231600A9169A /* TokenRefreshManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A9D7642DF3231600A9169A /* TokenRefreshManager.swift */; };
 		36BAF1C72CA483BC00BEBCE7 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BAF1C62CA483BC00BEBCE7 /* HomeView.swift */; };
 		36BAF1CD2CA48BAE00BEBCE7 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BAF1CC2CA48BAE00BEBCE7 /* HomeModel.swift */; };
 		36C1FE052CA4A4EC007CA188 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C1FE042CA4A4EC007CA188 /* HomeViewModel.swift */; };
@@ -297,6 +298,7 @@
 		369F16F42D8707E50039ED3A /* RankRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankRepository.swift; sourceTree = "<group>"; };
 		369F16F82D99A3850039ED3A /* CustomScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomScrollView.swift; sourceTree = "<group>"; };
 		36A9D6EF2DE5E41800A9169A /* SwipeBackEnabledModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeBackEnabledModifier.swift; sourceTree = "<group>"; };
+		36A9D7642DF3231600A9169A /* TokenRefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRefreshManager.swift; sourceTree = "<group>"; };
 		36BAF1C62CA483BC00BEBCE7 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		36BAF1CC2CA48BAE00BEBCE7 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		36BAF1CE2CA4919C00BEBCE7 /* HomeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeButton.swift; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 				F88663D22CC8EE29008DB860 /* AuthNetwork.swift */,
 				F88FC6DB2CCF3B110033D4C9 /* PetsNetwork.swift */,
 				367A796E2CDCBC210055771B /* PathString.swift */,
+				36A9D7642DF3231600A9169A /* TokenRefreshManager.swift */,
 				367A79DC2CE4B65D0055771B /* TokenInterceptor.swift */,
 				36F6E7EA2CEE411D00B395FB /* Config.swift */,
 				364195A62D72F0430065C400 /* RankNetwork.swift */,
@@ -1282,6 +1285,7 @@
 				F8C10C1A2C57970B0037D6A5 /* SignUpTermView.swift in Sources */,
 				F88663D72CC8F0D2008DB860 /* LoginViewModel.swift in Sources */,
 				F88FC6DC2CCF3B110033D4C9 /* PetsNetwork.swift in Sources */,
+				36A9D7652DF3231600A9169A /* TokenRefreshManager.swift in Sources */,
 				F80DF7362CB38861004FF1F2 /* WebView.swift in Sources */,
 				36465DAC2CFA415200784E8A /* LottieString.swift in Sources */,
 				36F6E8212CEE7DE000B395FB /* CheckButton.swift in Sources */,

--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -831,10 +831,10 @@
 		F89A2EBA2C7C80AF00FE3A36 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				F9F56EDB2D9B6E710085E266 /* Event */,
 				367A79A92CDE07900055771B /* Extension */,
 				F8758CF02C8EDF6B0038CCBB /* HealthKitManager.swift */,
 				F90329EB2D96A071004A8360 /* AnalyticsManager.swift */,
-				F9F56EDB2D9B6E710085E266 /* Event */,
 				F809E2FB2CBD06A1001BE099 /* UserManager.swift */,
 				F85C2BA32C4CD651002E2237 /* UserDefaultValue.swift */,
 				363CC4472CCADC6A00D2EE47 /* WatchConnectivityManager.swift */,

--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -1625,7 +1625,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = inc.ddanddan.DDanDDan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1672,7 +1672,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = inc.ddanddan.DDanDDan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -143,7 +143,8 @@ struct ContentView: View {
     @EnvironmentObject var user: UserManager
     
     var body: some View {
-        NavigationStack(path: $coordinator.navigationPath) {
+        user.coordinator = coordinator
+        return NavigationStack(path: $coordinator.navigationPath) {
             switch coordinator.rootView {
             case .splash:
                 SplashView(viewModel: SplashViewModel(coordinator: coordinator, homeRepository: HomeRepository()))

--- a/DDanDDan/Network/AuthNetwork.swift
+++ b/DDanDDan/Network/AuthNetwork.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 
 public struct AuthNetwork {
-    private let manager = NetworkManager()
+    private let manager = NetworkManager(withInterceptor: false)
     
     public func login(token: String, tokenType: String, deviceToken: String?) async -> Result<LoginData, NetworkError> {
         var parameter: Parameters = [
@@ -20,7 +20,13 @@ public struct AuthNetwork {
             parameter["deviceToken"] = deviceToken
         }
         
-        return await manager.request(url: "/v1/auth/login", method: .post, parameters: parameter, encoding: JSONEncoding.default)
+        return await manager.request(
+                url: PathString.Auth.login,
+                method: .post,
+                parameters: parameter,
+                encoding: JSONEncoding.default,
+                excludeAuth: true
+            )
     }
     
     public func tokenReissue(refreshToken: String) async -> Result<ReissueData, NetworkError> {
@@ -28,6 +34,12 @@ public struct AuthNetwork {
             "refreshToken": refreshToken
         ]
         
-        return await manager.request(url: PathString.Auth.reissue, method: .post, parameters: parameter, encoding: JSONEncoding.default)
+        return await manager.request(
+            url: PathString.Auth.reissue,
+            method: .post,
+            parameters: parameter,
+            encoding: JSONEncoding.default,
+            excludeAuth: true
+        )
     }
 }

--- a/DDanDDan/Network/NetworkManager.swift
+++ b/DDanDDan/Network/NetworkManager.swift
@@ -12,44 +12,64 @@ public struct NetworkManager {
     private let baseURL = Config.baseURL
     private let session: Session
     
-    public init(interceptor: Interceptor? = nil) {
+    public init(withInterceptor:Bool = true) {
         let config = URLSessionConfiguration.default
         config.requestCachePolicy = .returnCacheDataElseLoad
-        self.session = Session(configuration: config, interceptor: interceptor)
+        self.session = Session(configuration: config, interceptor: withInterceptor ? TokenInterceptor() : nil)
+        
     }
+    
+    private func createHeaders(excludeAuth: Bool = false, additionalHeaders: HTTPHeaders? = nil) -> HTTPHeaders {
+        var headers: HTTPHeaders = [
+            "Content-Type": "application/json"
+        ]
+        
+        if !excludeAuth, let accessToken = UserDefaultValue.acessToken {
+            headers["Authorization"] = "Bearer \(accessToken)"
+        }
+        
+        if let additionalHeaders = additionalHeaders {
+            for header in additionalHeaders {
+                headers[header.name] = header.value
+            }
+        }
+        
+        return headers
+    }
+
     
     public func request<T: Decodable>(
         url: String,
         method: HTTPMethod,
         headers: HTTPHeaders? = nil,
         parameters: Parameters? = nil,
-        encoding: ParameterEncoding = URLEncoding.default
+        encoding: ParameterEncoding = URLEncoding.default,
+        excludeAuth: Bool = false
     ) async -> Result<T, NetworkError> {
         guard let url = URL(string: baseURL + url) else {
             return .failure(NetworkError.urlError)
         }
+        let networkHeaders = createHeaders(excludeAuth: excludeAuth, additionalHeaders: headers)
         
-        // 네트워크 로그 출력
         print("\n📡 Request:")
         print("🔹 URL: \(url)")
         print("🔹 Method: \(method.rawValue)")
-        if let headers = headers {
-            print("🔹 Headers: \(headers)")
-        }
+        print("🔹 Headers: \(networkHeaders)")
+        
         if let parameters = parameters {
             print("🔹 Parameters: \(parameters)")
         }
         
-        AnalyticsManager.shared.logEvent(event: NetworkEvent.request(url: url.absoluteString, header: headers?.description, params: parameters?.description))
+        AnalyticsManager.shared.logEvent(event: NetworkEvent.request(url: url.absoluteString, header: networkHeaders.description, params: parameters?.description))
        
-        let result = await session.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
+        let result = await session.request(url, method: method, parameters: parameters, encoding: encoding, headers: networkHeaders)
             .validate(statusCode: 200..<401)
             .serializingData()
             .response
         
         // 응답 로그 출력
         print("\n📥 Response:")
-        if let error = result.error as? AFError {
+        if let error = result.error {
             print("🔹 AFError: \(error.localizedDescription)")
             
             if let statusCode = error.responseCode {

--- a/DDanDDan/Network/NetworkManager.swift
+++ b/DDanDDan/Network/NetworkManager.swift
@@ -24,7 +24,7 @@ public struct NetworkManager {
             "Content-Type": "application/json"
         ]
         
-        if !excludeAuth, let accessToken = UserDefaultValue.acessToken {
+        if !excludeAuth, let accessToken = UserDefaultValue.accessToken {
             headers["Authorization"] = "Bearer \(accessToken)"
         }
         

--- a/DDanDDan/Network/PathString.swift
+++ b/DDanDDan/Network/PathString.swift
@@ -22,6 +22,7 @@ enum PathString {
     }
     
     enum Auth {
+        static let login = "/v1/auth/login"
         static let reissue = "/v1/auth/reissue"
     }
     

--- a/DDanDDan/Network/PetsNetwork.swift
+++ b/DDanDDan/Network/PetsNetwork.swift
@@ -10,27 +10,21 @@ import Foundation
 import Alamofire
 
 public struct PetsNetwork {
-    private let manager = NetworkManager(interceptor: TokenInterceptor())
+    private let manager = NetworkManager()
     
     // MARK: - GET
     
     public func fetchSpecificPet(accessToken: String, petId: String) async -> Result<Pet, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.Pet.fetchPet + petId,
-            method: .get,
-            headers: headers
+            method: .get
         )
     }
     
     public func fetchPetArchieve(accessToken: String) async -> Result<PetArchiveModel, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.Pet.userPets,
-            method: .get,
-            headers: headers
+            method: .get
         )
     }
     
@@ -40,43 +34,34 @@ public struct PetsNetwork {
         let parameter: Parameters = [
             "petType": petType.rawValue
         ]
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
         
         return await manager.request(
             url: PathString.Pet.userPets,
             method: .post,
-            headers: headers,
             parameters: parameter,
             encoding: JSONEncoding.default
         )
     }
     
     public func addRandomPet(accessToken: String) async -> Result<Pet, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.Pet.randomPet,
-            method: .post,
-            headers: headers
+            method: .post
         )
     }
     
     public func postPetFeed(accessToken: String, petId: String) async -> Result<UserPetData, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.Pet.fetchPet + petId + "/food",
-            method: .post, headers: headers,
+            method: .post,
             encoding: JSONEncoding.default
         )
     }
     
     public func postPetPlay(accessToken: String, petId: String) async -> Result<UserPetData, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.Pet.fetchPet + petId + "/play",
-            method: .post, headers: headers,
+            method: .post,
             encoding: JSONEncoding.default
         )
     }

--- a/DDanDDan/Network/RankNetwork.swift
+++ b/DDanDDan/Network/RankNetwork.swift
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 
 public struct RankNetwork {
-    private let manager = NetworkManager(interceptor: TokenInterceptor())
+    private let manager = NetworkManager()
     
     // MARK: - GET
     public func fetchRankInfo(accessToken: String, criteria: String, periodType: String) async -> Result<RankInfo, NetworkError> {

--- a/DDanDDan/Network/TokenInterceptor.swift
+++ b/DDanDDan/Network/TokenInterceptor.swift
@@ -23,7 +23,7 @@ public final class TokenInterceptor: RequestInterceptor {
             return
         }
         
-        if let accessToken = UserDefaultValue.acessToken {
+        if let accessToken = UserDefaultValue.accessToken {
             adaptedRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         }
         

--- a/DDanDDan/Network/TokenRefreshManager.swift
+++ b/DDanDDan/Network/TokenRefreshManager.swift
@@ -1,0 +1,53 @@
+//
+//  TokenRefreshManager.swift
+//  DDanDDan
+//
+//  Created by 이지희 on 6/6/25.
+//
+
+import Foundation
+
+actor TokenRefreshManager {
+    private var isRefreshing = false
+    private var refreshTask: Task<Bool, Never>?
+    
+    func refresh() async -> Bool {
+        if let existingTask = refreshTask {
+            return await existingTask.value
+        }
+        
+        let task = Task<Bool, Never> {
+            isRefreshing = true
+            
+            let network = AuthNetwork()
+            let refreshToken = UserDefaultValue.refreshToken ?? ""
+            let result = await network.tokenReissue(refreshToken: refreshToken)
+            
+            switch result {
+            case .success(let reissueData):
+                print("🔹 토큰 재발급 완료")
+                UserDefaultValue.acessToken = reissueData.accessToken
+                UserDefaultValue.refreshToken = reissueData.refreshToken
+                return true
+                
+            case .failure(let failure):
+                print("🔻 토큰 재발급 실패: \(failure.localizedDescription)")
+                await UserManager.shared.logout()
+                return false
+            }
+        }
+        
+        refreshTask = task
+        let result = await task.value
+        
+        // Task 완료 후 정리
+        isRefreshing = false
+        refreshTask = nil
+        
+        return result
+    }
+    
+    var isCurrentlyRefreshing: Bool {
+        isRefreshing
+    }
+}

--- a/DDanDDan/Network/TokenRefreshManager.swift
+++ b/DDanDDan/Network/TokenRefreshManager.swift
@@ -26,7 +26,7 @@ actor TokenRefreshManager {
             switch result {
             case .success(let reissueData):
                 print("🔹 토큰 재발급 완료")
-                UserDefaultValue.acessToken = reissueData.accessToken
+                UserDefaultValue.accessToken = reissueData.accessToken
                 UserDefaultValue.refreshToken = reissueData.refreshToken
                 return true
                 

--- a/DDanDDan/Network/UserNetwork.swift
+++ b/DDanDDan/Network/UserNetwork.swift
@@ -8,27 +8,21 @@
 import Foundation
 import Alamofire
 public struct UserNetwork {
-    private let manager = NetworkManager(interceptor: TokenInterceptor())
+    private let manager = NetworkManager()
     
     // MARK: - GET
     
     public func fetchUserMainPet(accessToken: String) async -> Result<MainPet, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.User.mainPet,
-            method: .get,
-            headers: headers
+            method: .get
         )
     }
     
     public func fetchUserInfo(accessToken: String) async -> Result<UserData, NetworkError> {
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        
         return await manager.request(
             url: PathString.User.user,
-            method: .get,
-            headers: headers
+            method: .get
         )
     }
     
@@ -47,11 +41,9 @@ public struct UserNetwork {
         if let purposeCalorie = purposeCalorie {
             parameter["purposeCalorie"] = purposeCalorie
         }
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
         return await manager.request(
             url: PathString.User.user,
             method: .put,
-            headers: headers,
             parameters: parameter,
             encoding: JSONEncoding.default
         )
@@ -61,11 +53,9 @@ public struct UserNetwork {
     
     public func patchDailyKcal(accessToken: String, calorie: Int) async -> Result<DailyUserData, NetworkError> {
         let parameter: Parameters = ["calorie": calorie]
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
         return await manager.request(
             url: PathString.User.updateDailyKcal,
             method: .patch,
-            headers: headers,
             parameters: parameter,
             encoding: JSONEncoding.default
             )
@@ -73,11 +63,9 @@ public struct UserNetwork {
     
     public func patchPushNotification(accessToken: String, isOn: Bool) async -> Result<EmptyEntity, NetworkError> {
         let parameter: Parameters = ["isAppPushOn": isOn]
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
         return await manager.request(
             url: PathString.User.userSetting,
             method: .patch,
-            headers: headers,
             parameters: parameter,
             encoding: JSONEncoding.default
             )
@@ -87,11 +75,9 @@ public struct UserNetwork {
     
     public func setMainPet(accessToken: String, petID: String) async -> Result<MainPet, NetworkError> {
         let parameter: Parameters = ["petId": petID]
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
         return await manager.request(
             url: PathString.User.mainPet,
             method: .post,
-            headers: headers,
             parameters: parameter,
             encoding: JSONEncoding.default
         )
@@ -101,11 +87,11 @@ public struct UserNetwork {
     
     public func deleteUser(accessToken: String, reason: String) async -> Result<EmptyEntity, NetworkError> {
         let parameter: Parameters = ["cause": reason]
-        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
-        return await manager.request(url: PathString.User.user,
-                                     method: .delete,
-                                     headers: headers,
-                                     parameters: parameter,
-                                     encoding: JSONEncoding.default)
+        return await manager.request(
+            url: PathString.User.user,
+            method: .delete,
+            parameters: parameter,
+            encoding: JSONEncoding.default
+        )
     }
 }

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -15,7 +15,14 @@ final class HomeViewModel: ObservableObject {
     private struct Loading {
         var feed: Bool = false
     }
-    @Published var homePetModel: HomeModel = .init(petType: .pinkCat, level: 4, exp: 0, goalKcal: 0, feedCount: 4, toyCount: 0)
+    @Published var homePetModel: HomeModel = .init(
+        petType: PetType(rawValue: UserDefaultValue.petType) ?? .pinkCat,
+        level: UserDefaultValue.level,
+        exp: 0,
+        goalKcal: UserDefaultValue.purposeKcal,
+        feedCount: 0,
+        toyCount: 0
+    )
     
     @Published var isPlayingSpecialAnimation: Bool = false
 
@@ -271,7 +278,6 @@ final class HomeViewModel: ObservableObject {
                 self.homePetModel.toyCount = dailyInfo.user.toyQuantity
                 
                 UserDefaultValue.currentKcal = Double(dailyInfo.dailyInfo.calorie)
-                UserDefaultValue.date = dailyInfo.dailyInfo.date.toDate() ?? Date()
             }
         }
     }

--- a/DDanDDan/Repository/HomeRepository.swift
+++ b/DDanDDan/Repository/HomeRepository.swift
@@ -130,7 +130,7 @@ public struct HomeRepository: HomeRepositoryProtocol {
         let result = await authNetwork.tokenReissue(refreshToken: refreshToken)
         switch result {
         case .success(let reissueData):
-            UserDefaultValue.acessToken = reissueData.accessToken
+            UserDefaultValue.accessToken = reissueData.accessToken
             UserDefaultValue.refreshToken = reissueData.refreshToken
             return true
         case .failure:

--- a/DDanDDan/Util/UserDefaultValue.swift
+++ b/DDanDDan/Util/UserDefaultValue.swift
@@ -9,8 +9,8 @@ import Foundation
 
 public struct UserDefaultValue {
     //Auth
-    @UserDefault(key: "acessToken", defaultValue: nil)
-    static public var acessToken: String?
+    @UserDefault(key: "accessToken", defaultValue: nil)
+    static public var accessToken: String?
     @UserDefault(key: "refreshToken", defaultValue: nil)
     static public var refreshToken: String?
     @UserDefault(key: "deviceToken", defaultValue: nil)

--- a/DDanDDan/Util/UserManager.swift
+++ b/DDanDDan/Util/UserManager.swift
@@ -13,6 +13,8 @@ actor UserManager: ObservableObject {
     @MainActor @Published var accessToken: String? = UserDefaultValue.acessToken
     @MainActor public var kakaoToken: String?
     @MainActor public var appleToken: String?
+    @MainActor public var coordinator: AppCoordinator?
+    
     private var refreshToken: String? = UserDefaultValue.refreshToken
     private var deviceToken: String? = UserDefaultValue.refreshToken
     @MainActor private var isOnboardingComplete: Bool = UserDefaultValue.isOnboardingComplete
@@ -52,6 +54,7 @@ actor UserManager: ObservableObject {
         await MainActor.run {
             accessToken = nil
             UserDefaultValue.acessToken = nil
+            coordinator?.setRoot(to: .login)
         }
     }
 }


### PR DESCRIPTION
## MR 요약
### 토큰 재발급 로직 개선
#### 문제 상황
> 1) 네트워크 통신 중 401 에러 발생  
> 2) interceptor에서 retry 함수 호출 
> 3) 토큰 에러 확인 후 reissue 호출 
> 4) 토큰 재발급 성공 시 네트워크 재 호출

- 네트워크 재호출이 이뤄지지 않는 오류 발생
- reissue 호출 시 여러번 호출되는 오류 발생

#### 문제 원인
- 여러 개의 네트워크 통신이 한 번에 일어날 경우 retry 함수가 여러번 호출됨
- 토큰 재발급이 이뤄진 후 토큰이 업데이트 되지 않는 상태로 네트워크 재호출

#### 해결 방법
retry 중복 호출 문제
- 토큰 재발급 로직을 분리 후 Task를 활용해서 여러번 호출되지 않도록 처리
 
토큰 업데이트 문제
- Interceptor를 상속 받는 것이 아닌 RequestInterceptor 프로토콜을 구현하도록 변경.
- 재호출할 때 업데이트된 토큰을 사용할 수 있도록 adapt에서 업데이트된 토큰으로 Authorization 헤더 값 변경 후 adaptRequest 호출

refresh 토큰 만료 시 로그아웃 처리 개선
- 로그아웃 처리에 coordinator 이용 login 뷰로 이동하도록 변경

### 뷰 업데이트 개선
#### 홈 화면
로그인 / 회원 가입 이후 홈화면 진입 시 초기값으로 인해 다른 펫이 보이는 현상
- UserDefaults에 저장되어 있는 펫 정보를 초기값으로 갖도록 변경
#### 랭킹 화면
랭킹 화면 캐시 데이터 -> 로딩된 데이터 반영 시에 뷰 업데이트가 이뤄지지 않는 경우 존재
- DataLoadingState를 이용해서 로딩 상태 세부적으로 관리
- 데이터 UUID를 통해 반영이 되지 않았을 경우 강제 업데이트 로직 추가
```
    enum DataLoadingState: Equatable {
        case initial
        case loadingFromCache
        case loadingFromNetwork
        case completed
    }
```