### PR TITLE
fix: 토큰 갱신 및 로그아웃 로직 개선

### DIFF
--- a/DDanDDan/Network/NetworkManager.swift
+++ b/DDanDDan/Network/NetworkManager.swift
@@ -14,7 +14,7 @@ public struct NetworkManager {
     
     public init(withInterceptor:Bool = true) {
         let config = URLSessionConfiguration.default
-        config.requestCachePolicy = .returnCacheDataElseLoad
+        config.requestCachePolicy = .useProtocolCachePolicy
         self.session = Session(configuration: config, interceptor: withInterceptor ? TokenInterceptor() : nil)
     }
     

--- a/DDanDDan/Network/TokenInterceptor.swift
+++ b/DDanDDan/Network/TokenInterceptor.swift
@@ -12,7 +12,7 @@ public final class TokenInterceptor: RequestInterceptor {
     
     private let maxRetryCount = 3
     private var retryCount = 0
-    private let tokenRefreshManager = TokenRefreshManager()
+    private let tokenRefreshManager = TokenRefreshManager.shared
 
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         

--- a/DDanDDan/Network/TokenRefreshManager.swift
+++ b/DDanDDan/Network/TokenRefreshManager.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 actor TokenRefreshManager {
+    static let shared = TokenRefreshManager()
+    private init() {}
+
     private var isRefreshing = false
     private var refreshTask: Task<Bool, Never>?
     
@@ -28,6 +31,10 @@ actor TokenRefreshManager {
                 print("🔹 토큰 재발급 완료")
                 UserDefaultValue.accessToken = reissueData.accessToken
                 UserDefaultValue.refreshToken = reissueData.refreshToken
+                await UserManager.shared.setToken(
+                    accessToken: reissueData.accessToken,
+                    refreshToken: reissueData.refreshToken
+                )
                 return true
                 
             case .failure(let failure):

--- a/DDanDDan/Util/UserManager.swift
+++ b/DDanDDan/Util/UserManager.swift
@@ -54,6 +54,7 @@ actor UserManager: ObservableObject {
         await MainActor.run {
             accessToken = nil
             UserDefaultValue.accessToken = nil
+            UserDefaultValue.refreshToken = nil
             coordinator?.setRoot(to: .login)
         }
     }


### PR DESCRIPTION
## Summary
  - TokenRefreshManager를 싱글톤으로 변경하여 동시 다발적인 refresh 요청 방지
  - 토큰 갱신 후 UserManager(메모리)에도 토큰을 반영하여 디스크-메모리 동기화
  - 로그아웃 시 refreshToken도 함께 제거
  - NetworkManager 캐시 정책을 useProtocolCachePolicy로 변경

  ## 원인
  - TokenInterceptor가 생성될 때마다 TokenRefreshManager를 새로 생성하여 중복 refresh 발생 가능
  - 토큰 갱신 후 UserDefaultValue(디스크)만 업데이트하고 UserManager(메모리)는 갱신하지 않아 이후
  요청에서 만료된 토큰 사용

  ## 변경 파일
  - `TokenRefreshManager.swift` — 싱글톤 적용, 갱신 후 UserManager.setToken 호출
  - `TokenInterceptor.swift` — TokenRefreshManager.shared 사용
  - `UserManager.swift` — logout() 시 refreshToken nil 처리 추가
  - `NetworkManager.swift` — 캐시 정책 변경

  ## Test plan
  - [ ] 로그인 후 accessToken 만료 시 자동 갱신 확인
  - [ ] 동시 다발 API 호출 시 refresh 요청이 1회만 발생하는지 확인
  - [ ] 로그아웃 후 accessToken, refreshToken 모두 제거되었는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 원격 구성(Remote Config) 및 실시간 DB 연동 기능 추가로 런타임 설정과 강제 업데이트 검사 지원.
  * 앱 시작 시 원격 구성 가져오기를 수행하고 강제 업데이트 알림을 표시하는 흐름 추가.

* **Bug Fixes**
  * 네트워크 캐시 정책 개선 및 iOS 버전 헤더 추가로 요청 처리 신뢰성 향상.
  * 토큰 갱신 로직을 공유 인스턴스로 안정화하고 로그아웃 시 리프레시 토큰까지 삭제하도록 개선.
  * 친구 목록 렌더링 식별자 오류 수정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->