### PR TITLE
친구 삭제 시 크래시 수정

### DIFF
--- a/DDanDDan/Presenter/Friends/FriendsView.swift
+++ b/DDanDDan/Presenter/Friends/FriendsView.swift
@@ -111,7 +111,7 @@ struct FriendListView: View {
     
     private var friendsListView: some View {
         LazyVStack(spacing: 0) {
-            ForEach(store.friendsList, id: \.self) { friend in
+            ForEach(store.friendsList, id: \.id) { friend in
                 friendsListItemView(friend: friend)
             }
         }


### PR DESCRIPTION
  ## Summary
  - `FriendsView`의 `ForEach`에서 id 식별자를 `\.self`에서 `\.id`로 변경
  - `\.self` 사용 시 Friend의 모든 프로퍼티(name, petLevel 등)로 해시를 계산하여, 삭제 후 리스트 diff
   과정에서 크래시 발생
  - 서버 고유 식별자인 `id`만으로 뷰를 추적하도록 수정하여 안정적인 리스트 업데이트 보장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 친구 목록의 항목 추적 방식을 개선하여 목록 업데이트 시 더욱 안정적인 성능을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->