### PR TITLE
딥링크 친구 추가 시 버튼 확인 후 API 호출하도록 수정

### DIFF
--- a/DDanDDan/Entity/Friend/Friend.swift
+++ b/DDanDDan/Entity/Friend/Friend.swift
@@ -39,3 +39,7 @@ public struct FriendUser: Decodable, Equatable {
     let mainPetType: PetType
     let petLevel: Int
 }
+
+public struct InviteCodeInfo: Decodable, Equatable {
+    let inviterUser: FriendUser
+}

--- a/DDanDDan/Network/FriendNetwork.swift
+++ b/DDanDDan/Network/FriendNetwork.swift
@@ -22,6 +22,16 @@ public struct FriendNetwork {
         )
     }
     
+    public func fetchInviteCodeInfo(accessToken: String, inviteCode: String) async -> Result<InviteCodeInfo, NetworkError> {
+        let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]
+
+        return await manager.request(
+            url: PathString.Friend.inviteCodeInfo + inviteCode,
+            method: .get,
+            headers: headers
+        )
+    }
+
     // MARK: - POST
     public func createInviteCode(accessToken: String) async -> Result<InviteCode, NetworkError> {
         let headers: HTTPHeaders = ["Authorization": "Bearer " + accessToken]

--- a/DDanDDan/Network/PathString.swift
+++ b/DDanDDan/Network/PathString.swift
@@ -40,6 +40,7 @@ enum PathString {
         static let friendsList = "/v1/friends/me"
         static let deleteFriend = "/v1/friends/"
         static let createInviteCode = "/v1/friends/invite-codes"
+        static let inviteCodeInfo = "/v1/friends/invite-codes/"
         static let inviteFriend = "/v1/friends/by-invite/"
 
     }

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
@@ -128,6 +128,7 @@ struct FriendCardReducer {
                 state.isAddingFriend = false
                 switch result {
                 case .success(let addedFriend):
+                    state.dismiss = true
                     return .send(.delegate(.dismissAndNavigateToFriendAdd(addedFriend)))
                 case .failure(let error):
                     switch error {

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
@@ -110,6 +110,7 @@ struct FriendCardReducer {
                 case .invite(let user):
                     return .send(.delegate(.dismissAndNavigateToFriendAdd(user)))
                 case .pendingInvite(let code):
+                    guard !state.isAddingFriend else { return .none }
                     state.isAddingFriend = true
                     return addFriend(code: code)
                 }

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
@@ -16,6 +16,7 @@ struct FriendCardReducer {
     enum CardType: Equatable {
         case cheer
         case invite(user: AddedFriend)
+        case pendingInvite(code: String)
     }
     
     @ObservableState
@@ -42,15 +43,19 @@ struct FriendCardReducer {
             case .cheer:
                 entity?.isFriend == false || entity?.isCheeredToday == true || UserDefaultValue.userId == entity?.userId
             case .invite: false
+            case .pendingInvite: false
             }
         }
         var buttonTitle: String {
             switch type {
             case .cheer: "응원하기"
             case .invite: "친구하기"
+            case .pendingInvite: "친구하기"
             }
         }
-        
+
+        var isAddingFriend: Bool = false
+
         var badgeTitle: String? {
             if UserDefaultValue.userId == entity?.userId {
                 "나"
@@ -72,6 +77,7 @@ struct FriendCardReducer {
         case onCheerSuccess
         case setDismiss
         case inviteResult(TaskResult<AddedFriend>)
+        case addFriendResult(Result<AddedFriend, NetworkError>)
         case endFireAnimation
         
         case delegate(Delegate)
@@ -93,14 +99,19 @@ struct FriendCardReducer {
                     return fetchUserDetail(userID: state.userID)
                 case let .invite(user: user):
                     return fetchUserDetail(userID: user.friendUser.id)
+                case let .pendingInvite(code: code):
+                    return fetchInviteCodeInfo(code: code)
                 }
-                
+
             case .onTapButton:
                 switch state.type {
                 case .cheer:
                     return cheerFriend(userID: state.userID)
                 case .invite(let user):
                     return .send(.delegate(.dismissAndNavigateToFriendAdd(user)))
+                case .pendingInvite(let code):
+                    state.isAddingFriend = true
+                    return addFriend(code: code)
                 }
                 
             case let .inviteResult(result):
@@ -110,6 +121,33 @@ struct FriendCardReducer {
                 case .failure(let error):
                     print(error.localizedDescription)
                     return .none
+                }
+
+            case let .addFriendResult(result):
+                state.isAddingFriend = false
+                switch result {
+                case .success(let addedFriend):
+                    return .send(.delegate(.dismissAndNavigateToFriendAdd(addedFriend)))
+                case .failure(let error):
+                    switch error {
+                    case .serverError(_, let code):
+                        switch code {
+                        case "FR001":
+                            return showToast(&state, message: "이미 친구입니다.")
+                        case "FR002":
+                            return showToast(&state, message: "존재하지 않는 초대 코드입니다.")
+                        case "FR003":
+                            return showToast(&state, message: "자기 자신을 친구로 추가할 수 없습니다.")
+                        case "FR004":
+                            return showToast(&state, message: "친구 요청이 실패했습니다.")
+                        case "IC004":
+                            return showToast(&state, message: "자신의 초대코드는 사용할 수 없습니다.")
+                        default:
+                            return showToast(&state, message: "친구 추가에 실패했습니다.")
+                        }
+                    default:
+                        return showToast(&state, message: "친구 추가에 실패했습니다.")
+                    }
                 }
                 
             case .delegate:
@@ -154,6 +192,39 @@ struct FriendCardReducer {
         }
     }
     
+    private func fetchInviteCodeInfo(code: String) -> Effect<Action> {
+        return .run { send in
+            let result = await repository.fetchInviteCodeInfo(code)
+            switch result {
+            case .success(let info):
+                let entity = FriendCardEntity(
+                    userId: info.inviterUser.id,
+                    userName: info.inviterUser.name,
+                    mainPet: .init(
+                        id: "",
+                        type: info.inviterUser.mainPetType,
+                        level: info.inviterUser.petLevel,
+                        expPercent: 0
+                    ),
+                    todayCalorie: 0,
+                    monthlyReceivedCheerCount: 0,
+                    isFriend: false,
+                    isCheeredToday: false
+                )
+                await send(.setEntity(entity))
+            case .failure:
+                await send(.setDismiss)
+            }
+        }
+    }
+
+    private func addFriend(code: String) -> Effect<Action> {
+        return .run { send in
+            let result = await repository.addFriend(code)
+            await send(.addFriendResult(result))
+        }
+    }
+
     private func cheerFriend(userID: String) -> Effect<Action> {
         return .run { send in
             let result = await repository.cheerFriend(userID)

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
@@ -123,12 +123,12 @@ struct FriendCardView: View {
     
     var cardContentView: some View {
         VStack(spacing: 0) {
-            
+
             HStack(spacing: 8) {
                 Text(store.entity?.userName ?? "")
                     .font(.neoDunggeunmo22)
                     .foregroundStyle(.textHeadlinePrimary)
-                
+
                 Text("LV.\(store.entity?.mainPet.level ?? 0)")
                     .font(.neoDunggeunmo16)
                     .foregroundStyle(.textHeadlinePrimary)
@@ -138,47 +138,52 @@ struct FriendCardView: View {
                     .background(.elevationLevel02)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
             }
-            HStack(alignment: .center, spacing: 0) {
-                Image(.fire)
-                    .resizable()
-                    .frame(width: 20, height: 20)
-                
-                Text("받은 응원")
-                    .font(.body1_regular16)
-                    .foregroundStyle(.textBodyTeritary)
-                    .padding(.leading, 2)
-                
-                Text("\(store.entity?.monthlyReceivedCheerCount ?? 0)")
-                    .font(.neoDunggeunmo24)
-                    .baselineOffset(-2)
-                    .foregroundStyle(.textBodyTeritary)
-                    .padding(.leading, 8)
-                    
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 12)
-            .background(.elevationLevel02)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-            .padding(.top, 13)
-            
-            Rectangle()
-                .fill(.elevationLevel02)
-                .frame(height: 1)
-                .padding(.vertical, 20)
-            
-            VStack(spacing: 3) {
-                Text("오늘 소모 칼로리")
-                    .font(.body1_regular16)
-                    .foregroundStyle(.textBodyTeritary)
-                HStack(spacing: 2) {
-                    Text("\(store.entity?.todayCalorie ?? 0)")
-                        .font(.neoDunggeunmo20)
-                        .foregroundStyle(.textHeadlinePrimary)
-                    Text("kcal")
-                        .font(.neoDunggeunmo14)
-                        .foregroundStyle(.textHeadlinePrimary)
+
+            if case .pendingInvite = store.type {
+                EmptyView()
+            } else {
+                HStack(alignment: .center, spacing: 0) {
+                    Image(.fire)
+                        .resizable()
+                        .frame(width: 20, height: 20)
+
+                    Text("받은 응원")
+                        .font(.body1_regular16)
+                        .foregroundStyle(.textBodyTeritary)
+                        .padding(.leading, 2)
+
+                    Text("\(store.entity?.monthlyReceivedCheerCount ?? 0)")
+                        .font(.neoDunggeunmo24)
+                        .baselineOffset(-2)
+                        .foregroundStyle(.textBodyTeritary)
+                        .padding(.leading, 8)
+
                 }
-                
+                .padding(.vertical, 4)
+                .padding(.horizontal, 12)
+                .background(.elevationLevel02)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .padding(.top, 13)
+
+                Rectangle()
+                    .fill(.elevationLevel02)
+                    .frame(height: 1)
+                    .padding(.vertical, 20)
+
+                VStack(spacing: 3) {
+                    Text("오늘 소모 칼로리")
+                        .font(.body1_regular16)
+                        .foregroundStyle(.textBodyTeritary)
+                    HStack(spacing: 2) {
+                        Text("\(store.entity?.todayCalorie ?? 0)")
+                            .font(.neoDunggeunmo20)
+                            .foregroundStyle(.textHeadlinePrimary)
+                        Text("kcal")
+                            .font(.neoDunggeunmo14)
+                            .foregroundStyle(.textHeadlinePrimary)
+                    }
+
+                }
             }
         }
         .padding(.vertical, 28)

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
@@ -189,6 +189,8 @@ struct FriendCardView: View {
         case .invite:
             store.send(.onTapButton)
             store.send(.setDismiss)
+        case .pendingInvite:
+            store.send(.onTapButton)
         case .cheer:
             store.send(.onTapButton)
             let generator = UIImpactFeedbackGenerator(style: .medium)

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
@@ -62,6 +62,7 @@ struct FriendCardView: View {
                 .frame(width: 136, height: 56)
                 .background(Color.white)
                 .clipShape(RoundedRectangle(cornerRadius: 4))
+                .disabled(store.isAddingFriend)
             }
 
         }

--- a/DDanDDan/Presenter/Main/MainTabReducer.swift
+++ b/DDanDDan/Presenter/Main/MainTabReducer.swift
@@ -61,7 +61,11 @@ struct MainTabReducer {
                 state.navigateToFriendAdd = user
                 state.selectedTab = .friends
                 return .none
-                
+
+            case .friendCard(.presented(.delegate(.dismiss))):
+                state.friendCard = nil
+                return .none
+
             case .friendCard:
                 return .none
                 

--- a/DDanDDan/Presenter/Main/MainTabReducer.swift
+++ b/DDanDDan/Presenter/Main/MainTabReducer.swift
@@ -10,12 +10,9 @@ import ComposableArchitecture
 
 @Reducer
 struct MainTabReducer {
-    @Dependency(\.friendCardRepository) var repository: FriendCardRepository
-    
     @ObservableState
     struct State: Equatable {
         var selectedTab: TabType = .home
-        var isProcessingDeepLink: Bool = false
         var navigateToFriendAdd: AddedFriend? = nil
         
         var showToast: Bool = false
@@ -32,13 +29,12 @@ struct MainTabReducer {
     enum Action: BindableAction {
         case binding(BindingAction<State>)
         case handleDeepLink(inviteCode: String)
-        case addFriendResult(Result<AddedFriend, NetworkError>)
         case clearNavigateToFriendAdd
-        
+
         case rank(RankViewReducer.Action)
         case friends(FriendsViewReducer.Action)
         case setting(SettingViewReducer.Action)
-        
+
         // Scope
         case friendCard(PresentationAction<FriendCardReducer.Action>)
     }
@@ -70,49 +66,11 @@ struct MainTabReducer {
                 return .none
                 
             case let .handleDeepLink(inviteCode):
-                state.isProcessingDeepLink = true
-                return addFriend(code: inviteCode)
-                
-            case let .addFriendResult(result):
-                state.isProcessingDeepLink = false
-                
-                switch result {
-                case .success(let addedFriend):
-                    state.friendCard = FriendCardReducer.State(
-                        userID: "",
-                        type: .invite(user: addedFriend)
-                    )
-                    return .none
-                    
-                case .failure(let error):
-                    state.showToast = true
-                    print(error)
-                    switch error {
-                    case .serverError(_, let code):
-                        switch code {
-                        case "FR001":
-                            state.toastMessage = "이미 친구입니다."
-                        case "FR002":
-                            state.toastMessage = "존재하지 않는 초대 코드입니다."
-                        case "FR003":
-                            state.toastMessage = "자기 자신을 친구로 추가할 수 없습니다."
-                        case "FR004":
-                            state.toastMessage = "친구 요청이 실패했습니다."
-                        case "IC004":
-                            state.toastMessage = "자신의 초대코드는 사용할 수 없습니다."
-                        default:
-                            state.toastMessage = "친구 추가에 실패했습니다."
-                        }
-                    case .invalidResponse:
-                        state.toastMessage = "서버 응답이 올바르지 않습니다."
-                    default:
-                        state.toastMessage = "친구 추가에 실패했습니다."
-                    }
-                    return .run { send in
-                        try await Task.sleep(nanoseconds: 2_500_000_000)
-                        await send(.binding(.set(\.showToast, false)))
-                    }
-                }
+                state.friendCard = FriendCardReducer.State(
+                    userID: "",
+                    type: .pendingInvite(code: inviteCode)
+                )
+                return .none
                 
             case .clearNavigateToFriendAdd:
                 state.navigateToFriendAdd = nil
@@ -139,15 +97,4 @@ struct MainTabReducer {
         }
     }
     
-    private func addFriend(code: String) -> Effect<Action> {
-        return .run { send in
-            let result = await repository.addFriend(code)
-            switch result {
-            case .success(let friend):
-                await send(.addFriendResult(.success(friend)))
-            case .failure(let error):
-                await send(.addFriendResult(.failure(error)))
-            }
-        }
-    }
 }

--- a/DDanDDan/Repository/FriendCardRepository.swift
+++ b/DDanDDan/Repository/FriendCardRepository.swift
@@ -12,6 +12,7 @@ public struct FriendCardRepository: DependencyKey {
     var getFriendDetail: (_ userID: String) async -> Result<FriendCardEntity, NetworkError>
     var cheerFriend: (_ friendID: String) async -> Result<CheerInfo, NetworkError>
     var addFriend: (_ inviteCode: String) async -> Result<AddedFriend, NetworkError>
+    var fetchInviteCodeInfo: (_ inviteCode: String) async -> Result<InviteCodeInfo, NetworkError>
 }
 
 extension FriendCardRepository {
@@ -33,6 +34,10 @@ extension FriendCardRepository {
             addFriend: {
                 guard let accessToken = await UserManager.shared.accessToken else { return .failure(.requestFailed("Access Token Nil"))}
                 return await friendNetwork.addFriend(accessToken: accessToken, inviteCode: $0)
+            },
+            fetchInviteCodeInfo: {
+                guard let accessToken = await UserManager.shared.accessToken else { return .failure(.requestFailed("Access Token Nil"))}
+                return await friendNetwork.fetchInviteCodeInfo(accessToken: accessToken, inviteCode: $0)
             }
         )
     }


### PR DESCRIPTION
  Summary

  - 딥링크 수신 시 즉시 addFriend API를 호출하여 친구가 추가되던 버그 수정
  - FriendCard를 먼저 보여주고 "친구하기" 버튼을 눌렀을 때 API를 호출하도록 변경
  - 서버에 추가된 초대코드 조회 API(GET /v1/friends/invite-codes/{code}) 연동

  변경 흐름

  Before: 딥링크 → 즉시 addFriend API → FriendCard 표시 → 버튼 → 축하 화면
  After: 딥링크 → FriendCard 표시(초대자 정보 조회) → "친구하기" 버튼 → addFriend API → 축하 화면

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 초대 코드로 친구 추가 지원
  * 초대 코드 정보 자동 조회

* **UI 변경**
  * 대기 중인 초대 상태를 친구 카드에 표시
  * 초대 수락 버튼 누르는 동안 버튼 비활성화로 중복 입력 방지

* **동작/피드백 개선**
  * 초대 수락 결과에 따른 안내(성공 이동, 오류 토스트) 추가
  * 딥링크로 도착한 초대는 대기 중 카드로 열림
<!-- end of auto-generated comment: release notes by coderabbit.ai -->