### PR TITLE
fix: 강제 업데이트 검사 안정성 개선

### DIFF
--- a/DDanDDan/Presenter/Splash/SplashView.swift
+++ b/DDanDDan/Presenter/Splash/SplashView.swift
@@ -12,6 +12,7 @@ struct SplashView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var showUpdateAlert = false
     @State private var needsForceUpdate = false
+    @State private var isCheckingUpdate = false
 
     var body: some View {
         ZStack {
@@ -42,7 +43,8 @@ struct SplashView: View {
             }
         }
         .onChange(of: scenePhase) { newPhase in
-            if newPhase == .active, needsForceUpdate {
+            if newPhase == .active, needsForceUpdate, !isCheckingUpdate {
+                isCheckingUpdate = true
                 Task {
                     if await viewModel.checkForceUpdate() {
                         showUpdateAlert = true
@@ -50,6 +52,7 @@ struct SplashView: View {
                         needsForceUpdate = false
                         viewModel.navigateToNextScreen()
                     }
+                    isCheckingUpdate = false
                 }
             }
         }

--- a/DDanDDan/Presenter/Splash/SplashView.swift
+++ b/DDanDDan/Presenter/Splash/SplashView.swift
@@ -9,8 +9,10 @@ import SwiftUI
 
 struct SplashView: View {
     @StateObject var viewModel: SplashViewModel
+    @Environment(\.scenePhase) private var scenePhase
     @State private var showUpdateAlert = false
-    
+    @State private var needsForceUpdate = false
+
     var body: some View {
         ZStack {
             Color(.backgroundBlack)
@@ -33,9 +35,22 @@ struct SplashView: View {
         }
         .task {
             if await viewModel.checkForceUpdate() {
+                needsForceUpdate = true
                 showUpdateAlert = true
             } else {
                 viewModel.navigateToNextScreen()
+            }
+        }
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active, needsForceUpdate {
+                Task {
+                    if await viewModel.checkForceUpdate() {
+                        showUpdateAlert = true
+                    } else {
+                        needsForceUpdate = false
+                        viewModel.navigateToNextScreen()
+                    }
+                }
             }
         }
     }

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -65,8 +65,12 @@ final class SplashViewModel: ObservableObject {
         do {
             let path = "app_version/iOS"
             guard let data = try await RealtimeDBManager.shared.getDictionaryValue(path: path),
-                  let minVersion = data["minimum_version"] as? String else {
-                return checkCachedMinimumVersion()
+                  let minVersion = data["minimum_version"] as? String,
+                  !minVersion.isEmpty else {
+                UserDefaultValue.cachedMinimumVersion = nil
+                UserDefaultValue.cachedUpdateMessage = defaultMessage
+                self.updateAlertMessage = defaultMessage
+                return false
             }
 
             UserDefaultValue.cachedMinimumVersion = minVersion

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -61,19 +61,31 @@ final class SplashViewModel: ObservableObject {
     
     @MainActor
     func checkForceUpdate() async -> Bool {
+        let defaultMessage = "새로운 버전이 출시되었습니다. 원활한 사용을 위해 업데이트해 주세요."
         do {
             let path = "app_version/iOS"
             guard let data = try await RealtimeDBManager.shared.getDictionaryValue(path: path),
                   let minVersion = data["minimum_version"] as? String else {
-                return false
+                return checkCachedMinimumVersion()
             }
-            
-            self.updateAlertMessage = (data["update_message"] as? String) ?? "새로운 버전이 출시되었습니다. 원활한 사용을 위해 업데이트해 주세요."
+
+            UserDefaultValue.cachedMinimumVersion = minVersion
+            UserDefaultValue.cachedUpdateMessage = (data["update_message"] as? String) ?? defaultMessage
+
+            self.updateAlertMessage = UserDefaultValue.cachedUpdateMessage
             return isVersionLower(minimum: minVersion)
         } catch {
             print("Force update check failed: \(error)")
+            return checkCachedMinimumVersion()
+        }
+    }
+
+    private func checkCachedMinimumVersion() -> Bool {
+        guard let cached = UserDefaultValue.cachedMinimumVersion else {
             return false
         }
+        self.updateAlertMessage = UserDefaultValue.cachedUpdateMessage
+        return isVersionLower(minimum: cached)
     }
     
     private func isVersionLower(minimum: String) -> Bool {

--- a/DDanDDan/Util/UserDefaultValue.swift
+++ b/DDanDDan/Util/UserDefaultValue.swift
@@ -53,6 +53,12 @@ public struct UserDefaultValue {
     @UserDefault(key: "isFirstRandomTicket", defaultValue: true)
     static public var isFirstRandomTicket: Bool
 
+    // 강제 업데이트 캐시
+    @UserDefault(key: "cachedMinimumVersion", defaultValue: nil)
+    static public var cachedMinimumVersion: String?
+    @UserDefault(key: "cachedUpdateMessage", defaultValue: "새로운 버전이 출시되었습니다. 원활한 사용을 위해 업데이트해 주세요.")
+    static public var cachedUpdateMessage: String
+
     
 }
 


### PR DESCRIPTION
## Summary
- RTDB 조회 실패 시 캐시된 최소 버전으로 폴백하여 구버전 강제 업데이트 우회 방지
- `scenePhase` 감지로 앱스토어에서 업데이트 없이 복귀 시 재검사하여 스플래시 화면 갇힘 방지
- `UserDefaultValue`에 `cachedMinimumVersion`, `cachedUpdateMessage` 캐시 추가

## Test plan
- [ ] RTDB 정상 응답 시 기존과 동일하게 강제 업데이트 알림 표시 확인
- [ ] RTDB 조회 실패(네트워크 끊김 등) 시 캐시된 버전으로 강제 업데이트 판정 확인
- [ ] 앱스토어 이동 후 업데이트 없이 복귀 시 알림 재표시 확인
- [ ] 앱스토어에서 업데이트 완료 후 복귀 시 정상 진입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 앱이 활성화될 때 강제 업데이트 필요 여부를 재검사하여 복귀 시 알림/진행 상태를 올바르게 반영합니다.
  * 빠른 장면 전환 시 중복 확인이 발생하지 않도록 충돌 방지 로직을 추가했습니다.
* **새 기능**
  * 원격 확인 실패나 불완전한 응답 시 이전에 저장된 캐시된 업데이트 메시지와 버전 정보를 사용해 안정적으로 업데이트 여부를 판단합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->