### PR TITLE
뷰 이동 시 발생하는 에러 해결

### DIFF
--- a/DDanDDan/AppCoordinator.swift
+++ b/DDanDDan/AppCoordinator.swift
@@ -33,7 +33,12 @@ final class AppCoordinator: ObservableObject {
     @StateObject var user = UserManager.shared
     
     @Published private(set) var shouldUpdateHomeView = false
-    
+    @Published private(set) var petChangedSession: UUID = UUID()
+
+    func triggerPetChanged() {
+        petChangedSession = UUID()
+    }
+
     func setRoot(to path: AppPath) {
         Task { @MainActor in
             navigationPath.removeLast(navigationPath.count)

--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -210,6 +210,11 @@ struct ContentView: View {
                 LoginView(viewModel: LoginViewModel(repository: LoginRepository(), appCoordinator: coordinator))
             }
         }
+        .onChange(of: coordinator.rootView) { newValue in
+            if newValue == .mainTab {
+                mainTabStore = Store(initialState: MainTabReducer.State()) { MainTabReducer() }
+            }
+        }
     }
 }
 

--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -37,10 +37,10 @@ struct DDanDDanApp: App {
                 .environmentObject(deepLinkManager)
                 .onOpenURL { url in
                     if (AuthApi.isKakaoTalkLoginUrl(url)) {
-                        _ = AuthController.handleOpenUrl(url: url)
+                       _ = AuthController.handleOpenUrl(url: url)
+                    } else {
+                        ChottuLink.handleLink(url)
                     }
-                    
-                    ChottuLink.handleLink(url)
                 }
                 .task {
                     _ = await RemoteConfigManager.shared.fetchAndActivate()
@@ -104,7 +104,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 extension AppDelegate: MessagingDelegate{
     
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        
         print("---- receive fcmToken ----")
         let dataDict: [String: String] = ["token": fcmToken ?? ""]
         print(dataDict)
@@ -193,7 +192,8 @@ extension AppDelegate: ChottuLinkDelegate {
 struct ContentView: View {
     @EnvironmentObject var coordinator: AppCoordinator
     @EnvironmentObject var user: UserManager
-    
+    @State private var mainTabStore = Store(initialState: MainTabReducer.State()) { MainTabReducer() }
+
     var body: some View {
         user.coordinator = coordinator
         return NavigationStack(path: $coordinator.navigationPath) {
@@ -203,7 +203,7 @@ struct ContentView: View {
             case .signUp:
                 SignUpTermView(viewModel: SignUpViewModel(repository: SignUpRepository()), coordinator: coordinator)
             case .mainTab:
-                MainTabView(coordinator: coordinator, store: Store(initialState: MainTabReducer.State()) { MainTabReducer() })
+                MainTabView(coordinator: coordinator, store: mainTabStore)
             case .onboarding:
                 OnboardingView(coordinator: coordinator)
             case .login:

--- a/DDanDDan/Presenter/Friends/FriendsViewReducer.swift
+++ b/DDanDDan/Presenter/Friends/FriendsViewReducer.swift
@@ -73,6 +73,11 @@ struct FriendsViewReducer {
                 return .none
                 
             case .onAppear:
+                state.myProfilePet = .init(
+                    name: UserDefaultValue.nickName,
+                    petType: PetType(rawValue: UserDefaultValue.petType) ?? .pinkCat,
+                    level: UserDefaultValue.level
+                )
                 guard !state.hasLoadedOnce && !state.isLoading else {
                     return .none
                 }

--- a/DDanDDan/Presenter/Main/MainTabReducer.swift
+++ b/DDanDDan/Presenter/Main/MainTabReducer.swift
@@ -30,6 +30,7 @@ struct MainTabReducer {
         case binding(BindingAction<State>)
         case handleDeepLink(inviteCode: String)
         case clearNavigateToFriendAdd
+        case petChanged
 
         case rank(RankViewReducer.Action)
         case friends(FriendsViewReducer.Action)
@@ -78,6 +79,10 @@ struct MainTabReducer {
                 
             case .clearNavigateToFriendAdd:
                 state.navigateToFriendAdd = nil
+                return .none
+
+            case .petChanged:
+                state.rankState = RankViewReducer.State()
                 return .none
                 
             case .binding:

--- a/DDanDDan/Presenter/Main/MainTabView.swift
+++ b/DDanDDan/Presenter/Main/MainTabView.swift
@@ -110,6 +110,9 @@ struct MainTabView: View {
                     didSetupBindings = true
                 }
             }
+            .onReceive(coordinator.$petChangedSession) { _ in
+                store.send(.petChanged)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .friendInviteDeepLink)) { notification in
                 if let inviteCode = notification.object as? String {
                     store.send(.handleDeepLink(inviteCode: inviteCode))

--- a/DDanDDan/Presenter/Rank/RankViewReducer.swift
+++ b/DDanDDan/Presenter/Rank/RankViewReducer.swift
@@ -56,6 +56,7 @@ struct RankViewReducer: Reducer {
     
     enum Action {
         case onAppear
+        case resetState
         case onScenePhaseChange(ScenePhase)
         case tabChanged(Tab)
         case tabItem(Ranking)
@@ -80,6 +81,14 @@ struct RankViewReducer: Reducer {
             switch action {
             case .onAppear:
                 return handleonAppeared(&state)
+            case .resetState:
+                state.kcalRanking = nil
+                state.goalRanking = nil
+                state.cachedRanking = nil
+                state.dataLoadingState = .initial
+                state.kcalLoadingState = .initial
+                state.goalLoadingState = .initial
+                return .none
             case let .tabChanged(tab):
                 return handleTabChanged(&state, tab: tab)
             case .refreshTapped:
@@ -136,7 +145,7 @@ private extension RankViewReducer {
            state.goalRanking != nil {
             return .none
         }
-        
+
         // 캐시가 있으면 캐시 로딩
         if state.dataLoadingState == .loadingFromNetwork {
             return .none

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -63,6 +63,7 @@ struct PetArchiveView: View {
         .onChange(of: viewModel.isSelectedMainPet) { newValue in
             if newValue {
                 coordinator.triggerHomeUpdate(trigger: true)
+                coordinator.triggerPetChanged()
                 coordinator.pop()
             }
         }

--- a/DDanDDan/Presenter/Setting/SettingView.swift
+++ b/DDanDDan/Presenter/Setting/SettingView.swift
@@ -61,7 +61,7 @@ struct SettingView: View {
     
     var body: some View {
         WithViewStore(store) { $0 } content: { viewStore in
-            
+
             let logoutDialogBinding = viewStore.binding(get: \.showLogoutDialog,
                                                         send: SettingViewReducer.Action.showLogoutDialog)
             let notificationStateBinding = viewStore.binding(get: \.notificationState,
@@ -104,6 +104,9 @@ struct SettingView: View {
                         }
                     }
                 }
+            }
+            .onAppear {
+                viewStore.send(.onAppear)
             }
         }
         .navigationBarHidden(true)

--- a/DDanDDan/Presenter/Setting/SettingViewReducer.swift
+++ b/DDanDDan/Presenter/Setting/SettingViewReducer.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 
 struct SettingViewReducer: Reducer {
     enum Action {
+        case onAppear
         case toggleNotification(Bool)
         case showLogoutDialog(Bool)
         case toastMessage(String)
@@ -29,6 +30,9 @@ struct SettingViewReducer: Reducer {
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.notificationState = UserDefaultValue.pushNotification
+                return .none
             case .toggleNotification:
                 let state = state.notificationState
                 return .run { send in

--- a/DDanDDan/Repository/HomeRepository.swift
+++ b/DDanDDan/Repository/HomeRepository.swift
@@ -45,6 +45,7 @@ public struct HomeRepository: HomeRepositoryProtocol {
             AnalyticsManager.shared.setUserProperty(property: .userID(userData.id))
             AnalyticsManager.shared.setUserProperty(property: .userName(userData.name))
             UserDefaultValue.nickName = userData.name
+            UserDefaultValue.pushNotification = userData.setting.isAppPushOn
             return HomeUserInfo(
                 id: userData.id,
                 purposeCalorie: userData.purposeCalorie,


### PR DESCRIPTION
## PR 요약
- 로그아웃 후 재 로그인 시 첫 화면 설정 오류 수정
- 푸시 알림 설정 반영 안되는 오류 수정
- 펫 변경 시 리스트 뷰(랭킹, 친구목록)에 반영되지 않는 오류 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 반려동물 변경 이벤트를 감지해 주요 화면이 자동 갱신됩니다.
  * 메인탭의 내부 상태를 화면 전환 시 재초기화 및 유지하도록 개선.

* **버그 수정**
  * 랭킹 화면의 상태 초기화 로직 추가로 일관성·안정성 강화.
  * 카카오톡 로그인 URL 처리 흐름 개선.

* **개선**
  * 설정 진입 시 알림 설정을 자동으로 불러오고 저장합니다.
  * 친구 목록 화면에서 반려동물 정보 초기화 보장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->