### PR TITLE
fix: iOS↔Android 친구추가 딥링크 호환성 수정

### DIFF
--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -171,18 +171,16 @@ extension AppDelegate: ChottuLinkDelegate {
         let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let url = URL(string: trimmed),
               let host = url.host,
-              host.hasSuffix(allowedHostSuffix) else { return nil }
-        
-        var path = url.path
-        while path.last == "/" { path.removeLast() }
-        guard !path.isEmpty else { return nil }
-        
-        let rawCode = (path as NSString).lastPathComponent
+              host.hasSuffix(allowedHostSuffix),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let rawCode = components.queryItems?.first(where: { $0.name == "code" })?.value,
+              !rawCode.isEmpty else { return nil }
+
         let code = rawCode.removingPercentEncoding ?? rawCode
-        
-        let pattern = #"^[A-Za-z0-9_-]{4,64}$"#
-        if code.range(of: pattern, options: .regularExpression) == nil { return nil }
-        
+
+        let pattern = #"^[A-Za-z0-9]{4,64}$"#
+        guard code.range(of: pattern, options: .regularExpression) != nil else { return nil }
+
         return code
     }
     

--- a/DDanDDan/DeepLinkManager.swift
+++ b/DDanDDan/DeepLinkManager.swift
@@ -42,28 +42,28 @@ struct InviteLinkBuilder {
     
     /// 서버에서 받은 친구 코드로 초대 링크 생성
     func makeInviteURL(friendCode: String) async -> URL? {
-        guard !friendCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return nil
-        }
-        
+        let trimmed = friendCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var components = URLComponents(url: baseInviteURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [URLQueryItem(name: "code", value: trimmed)]
+        guard let destination = components?.url?.absoluteString else { return nil }
+
         let builder = CLDynamicLinkBuilder(
-            destinationURL: baseInviteURL.absoluteString,
+            destinationURL: destination,
             domain: "ddanddan.chottu.link"
         )
             .setIOSBehaviour(.app)
-            .setAndroidBehaviour(.browser)
+            .setAndroidBehaviour(.app)
             .setLinkName("friend-invite")
-            .setSelectedPath(friendCode)
             .build()
-        
+
         do {
             let shortURL = try await ChottuLink.createDynamicLink(for: builder)
             print("✅ Created link: \(shortURL)")
             return URL(string: shortURL ?? "")
-            // Share the link with your users
         } catch {
             print("❌ Failed to create link: \(error)")
-            // Handle the error appropriately
             return nil
         }
     }


### PR DESCRIPTION
## Summary

- 친구 초대 딥링크를 iOS에서 Android와 동일한 `?code=<코드>` query 파라미터 방식으로 통일
- `.setAndroidBehaviour(.browser)` → `.setAndroidBehaviour(.app)` 로 변경해 Android App Link intent-filter(autoVerify) 가 발동하도록 함
- 파싱 로직을 path lastPathComponent 추출 → `URLComponents.queryItems` 의 `code` 값 추출로 변경

## 문제 원인

서버 사양은 동일(`POST /v1/friends/by-invite/{code}`)하지만 iOS와 Android가 ChottuLink SDK 에 친구코드를 **부착/추출하는 위치가 비대칭**이어서 크로스플랫폼 딥링크가 동작하지 않았음.

| 방향 | originalURL 형태 | 수신 측 추출 방식 | 결과 |
|---|---|---|---|
| iOS → iOS | `.../ABC12345` (path) | path lastPathComponent | OK |
| Android → Android | `?code=ABC12345` (query) | `getQueryParameter("code")` | OK |
| **iOS → Android** | path 형식 | query `code` | **null → 실패** |
| **Android → iOS** | query 형식, path 비어있음 | path lastPathComponent (`!path.isEmpty` 가드) | **nil → 실패** |

Android 는 이미 query 방식으로 구현돼 있어 건드릴 필요가 없고, **iOS 만 수정**해 양쪽을 통일함.

## 변경 흐름

**Before (iOS 발급):**
```swift
CLDynamicLinkBuilder(destinationURL: "https://ddanddan.chottu.link", domain: ...)
    .setIOSBehaviour(.app)
    .setAndroidBehaviour(.browser)
    .setSelectedPath(friendCode)   // path 에 코드 부착
    .build()
```

**After:**
```swift
var components = URLComponents(url: baseInviteURL, resolvingAgainstBaseURL: false)
components?.queryItems = [URLQueryItem(name: "code", value: trimmed)]
CLDynamicLinkBuilder(destinationURL: components?.url?.absoluteString, domain: ...)
    .setIOSBehaviour(.app)
    .setAndroidBehaviour(.app)
    .build()
```

**Before (iOS 수신/파싱):** `url.path` 의 lastPathComponent 추출 → query 형식 URL 에서 실패
**After:** `URLComponents.queryItems` 에서 `name == "code"` 값 추출

## Test plan

- [ ] iOS 빌드 성공 확인 (ChottuLink API 키 세팅 필요)
- [ ] iOS → iOS: 복사한 링크를 다른 iOS 기기에서 탭 → 친구추가 정상 동작 (회귀 확인)
- [ ] iOS → Android: 복사한 링크를 Android 기기로 전달 → 탭 시 앱이 열리고 친구추가 진행
- [ ] Android → iOS: Android 링크를 iOS 에서 탭 → 앱 열리고 친구추가 진행
- [ ] Android → Android: 회귀 확인
- [ ] 서버 로그에서 `POST /v1/friends/by-invite/{code}` 200 OK 확인 (404 `IC001` / 409 `FR002` 가 아닌지)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 딥링크 초대 코드 추출을 URL 경로 대신 쿼리 파라미터에서 안정적으로 처리하도록 변경했습니다.
  * 초대 코드 검증을 강화하여 숫자와 영문자만 허용하도록 업데이트했습니다.
* **개선**
  * 초대 링크 생성 흐름을 간소화하고 입력값을 정리해 실패 가능성을 줄였습니다.
  * Android 동적 링크 동작을 앱 실행 쪽으로 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->