### PR TITLE
fix: iOS 간 딥링크 친구 초대 코드 추출 오류 수정

### DIFF
--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -149,7 +149,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
 extension AppDelegate: ChottuLinkDelegate {
     func chottuLink(didResolveDeepLink link: URL, metadata: [String : Any]?) {
-        if let code = extractChottuInviteCode(from: link.absoluteString) {
+        let code: String? = {
+            if let originalURL = metadata?["originalURL"] as? String,
+               let extracted = extractChottuInviteCode(from: originalURL) {
+                return extracted
+            }
+            return extractChottuInviteCode(from: link.absoluteString)
+        }()
+
+        if let code {
             DispatchQueue.main.async {
                 DeepLinkManager.shared.handleFriendInvite(code: code)
             }

--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -149,15 +149,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
 extension AppDelegate: ChottuLinkDelegate {
     func chottuLink(didResolveDeepLink link: URL, metadata: [String : Any]?) {
-        if let metadata = metadata {
-            print("📦 Metadata: \(metadata)")
-            let originURL = metadata["originalURL"] as? String
-            if let originURL = originURL {
-                if let code = extractChottuInviteCode(from: originURL) {
-                    DispatchQueue.main.async {
-                        DeepLinkManager.shared.handleFriendInvite(code: code)
-                    }
-                }
+        if let code = extractChottuInviteCode(from: link.absoluteString) {
+            DispatchQueue.main.async {
+                DeepLinkManager.shared.handleFriendInvite(code: code)
             }
         }
     }


### PR DESCRIPTION
## Summary
- `chottuLink(didResolveDeepLink:metadata:)`에서 `metadata["originalURL"]`(ChottuLink 단축 URL) 대신 resolve된 `link` 파라미터(목적지 URL)를 사용하도록 수정
- 이전 수정(`fix/deeplink-cross-platform`)에서 친구 코드를 URL path → query parameter(`?code=`)로 변경했으나, 단축 URL에는 query parameter가 포함되지 않아 iOS↔iOS 친구 추가가 실패하던 문제 해결

## Test plan
- [ ] iOS → iOS 친구 초대 링크 공유 후 친구 추가 정상 동작 확인
- [ ] Android → iOS 친구 초대 링크 공유 후 친구 추가 정상 동작 확인
- [ ] iOS → Android 친구 초대 링크 공유 후 친구 추가 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 친구 초대 링크 처리 로직을 개선하여 초대 코드 추출을 더 신뢰성 있게 수행하고, 유효한 코드가 있을 때만 초대 처리를 실행하도록 변경하여 불필요한 처리와 오류 발생 가능성을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->