### PR TITLE
fix: 앱 실행 중 Universal Link 딥링크 미수신 문제 수정

### DIFF
--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -98,6 +98,17 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print(error.localizedDescription)
     }
+
+    func application(_ application: UIApplication,
+                     continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+           let url = userActivity.webpageURL {
+            ChottuLink.handleLink(url)
+            return true
+        }
+        return false
+    }
 }
 
 


### PR DESCRIPTION
## Summary

- 앱이 이미 켜져있는 상태에서 친구 초대 딥링크를 탭하면 친구 추가 페이지로 랜딩되지 않는 문제 수정
- `AppDelegate`에 `application(_:continue:restorationHandler:)` 추가

## 원인

`ddanddan.chottu.link`은 Universal Link(Associated Domains `applinks:`)로 등록되어 있어, iOS가 앱 상태에 따라 URL 전달 경로를 다르게 처리함:

| 앱 상태 | URL 전달 경로 | 기존 처리 | 결과 |
|---|---|---|---|
| 꺼져있음 (Cold) | 초기 URL → `.onOpenURL` | `ChottuLink.handleLink(url)` | ✅ 동작 |
| 켜져있음 (Warm) | `NSUserActivity` → `application(_:continue:restorationHandler:)` | **미구현** | ❌ 실패 |

앱이 이미 실행 중일 때 Universal Link는 `NSUserActivity`로 전달되는데, AppDelegate에 해당 메서드가 없어 URL이 `ChottuLink.handleLink`에 도달하지 못했음.

## 변경 내용

`AppDelegate`에 `application(_:continue:restorationHandler:)` 추가:
```swift
func application(_ application: UIApplication,
                 continue userActivity: NSUserActivity,
                 restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
    if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
       let url = userActivity.webpageURL {
        ChottuLink.handleLink(url)
        return true
    }
    return false
}
```

## Test plan

- [ ] 앱이 **꺼져있는 상태**에서 친구 초대 링크 탭 → 앱 실행 후 친구 카드 표시 (회귀 확인)
- [ ] 앱이 **백그라운드에 있는 상태**에서 친구 초대 링크 탭 → 앱 포어그라운드 전환 후 친구 카드 표시
- [ ] 앱이 **포어그라운드에 있는 상태**에서 Safari/메모 등에서 링크 탭 → 친구 카드 표시
- [ ] 카카오 로그인 딥링크 회귀 확인 (기존 `.onOpenURL`의 카카오 처리에 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 유니버설 링크 지원이 추가되었습니다. 이제 웹 링크를 클릭할 때 앱이 자동으로 열려 관련 콘텐츠에 직접 접근할 수 있습니다. 웹 브라우저를 거치지 않고 앱 내에서 바로 해당 페이지를 볼 수 있어 더욱 편리한 사용 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->