### PR TITLE
feat: 홈 코치마크 (먹이/놀이 안내) 추가

### DIFF
--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -49,7 +49,9 @@ struct HomeView: View {
                 levelView
                     .padding(.bottom, 12.adjusted)
                     .padding(.horizontal, isSEDevice ? 28 : 32.adjustedWidth)
-                actionButtonView
+                // 액션 버튼 자리만 잡고, 실제 렌더링은 actionButtonsLayer에서 (코치마크 dim 위로 띄우기 위함)
+                Color.clear
+                    .frame(height: 95)
                     .padding(.horizontal, isSEDevice ? 28 : 32.adjustedWidth)
                     .padding(.bottom, 23.adjustedHeight)
             }
@@ -71,7 +73,39 @@ struct HomeView: View {
             .padding(.top, isSEDevice ? 16 : 60.adjustedHeight)
             .opacity(viewModel.showRandomPetGuide ? 1 : 0)
             .animation(.easeInOut(duration: 0.6), value: viewModel.showRandomPetGuide)
-            
+
+            // 코치마크 dim
+            Color(.backgroundBlack)
+                .ignoresSafeArea()
+                .opacity((viewModel.showFeedCoachMark || viewModel.showPlayCoachMark) ? 0.8 : 0)
+                .animation(.easeInOut(duration: 0.6), value: viewModel.showFeedCoachMark)
+                .animation(.easeInOut(duration: 0.6), value: viewModel.showPlayCoachMark)
+
+            // 액션 버튼 레이어 — 메인 VStack과 동일 위치, dim 위로 떠 있음
+            actionButtonsLayer
+
+            // 코치마크 안내 텍스트 + CTA (중앙)
+            if viewModel.showFeedCoachMark {
+                coachMarkText(
+                    headline: "100kcal를 소모할 때 마다\n먹이 1개를 받아요",
+                    subtitle: "'먹이주기' 버튼을 누르면 먹이를 줄 수 있어요",
+                    buttonTitle: "다음",
+                    accessibilityLabel: "다음 코치마크 보기"
+                ) {
+                    viewModel.tapFeedCoachMarkNext()
+                }
+            }
+            if viewModel.showPlayCoachMark {
+                coachMarkText(
+                    headline: "3일동안 목표를 달성하면\n펫을 놀아줄 수 있어요",
+                    subtitle: "'놀아주기' 버튼을 누르면 놀아줄 수 있어요",
+                    buttonTitle: "시작하기",
+                    accessibilityLabel: "코치마크 닫고 시작하기"
+                ) {
+                    viewModel.tapPlayCoachMarkStart()
+                }
+            }
+
             TransparentOverlayView(isPresented: viewModel.showToast, isDimView: false) {
                 VStack {
                     ToastView(message: viewModel.toastMessage, toastType: .info)
@@ -122,6 +156,9 @@ struct HomeView: View {
                     coordinator.triggerHomeUpdate(trigger: false)
                 }
             }
+        }
+        .onAppear {
+            viewModel.startHomeCoachMarkIfNeeded()
         }
     }
     
@@ -270,18 +307,90 @@ extension HomeView {
     var actionButtonView: some View {
         HStack(spacing: 12.adjusted) {
             HomeButton(buttonTitle: "먹이주기", count: viewModel.homePetModel.feedCount, image: .iconFeed)
+                .shadow(color: viewModel.showFeedCoachMark ? .white : .clear,
+                        radius: viewModel.showFeedCoachMark ? 32 : 0)
+                .opacity(viewModel.showPlayCoachMark ? 0.3 : 1.0)
                 .onTapGesture {
+                    guard !viewModel.showFeedCoachMark, !viewModel.showPlayCoachMark else { return }
                     AnalyticsManager.shared.logEvent(event: HomeEvent.clickFeedBtn)
                     viewModel.feedPet()
                 }
             HomeButton(buttonTitle: "놀아주기", count: viewModel.homePetModel.toyCount, image: .iconToy)
+                .shadow(color: viewModel.showPlayCoachMark ? .white : .clear,
+                        radius: viewModel.showPlayCoachMark ? 32 : 0)
+                .opacity(viewModel.showFeedCoachMark ? 0.3 : 1.0)
                 .onTapGesture {
+                    guard !viewModel.showFeedCoachMark, !viewModel.showPlayCoachMark else { return }
                     AnalyticsManager.shared.logEvent(event: HomeEvent.clickPlayBtn)
                     viewModel.playWithPet()
                 }
         }
         .frame(maxWidth: .infinity)
         .frame(height: 95)
+        .animation(.easeInOut(duration: 0.6), value: viewModel.showFeedCoachMark)
+        .animation(.easeInOut(duration: 0.6), value: viewModel.showPlayCoachMark)
+    }
+
+    // MARK: - Coach Mark Layers
+
+    /// 메인 VStack과 동일한 padding/spacing 구조의 placeholder들로 액션 버튼 위치를 동기화하고,
+    /// 그 자리에 진짜 actionButtonView를 한 번만 그린다 (단일 source of truth, dim 위로 떠 있음).
+    var actionButtonsLayer: some View {
+        VStack(alignment: .center) {
+            HStack {
+                Color.clear
+                    .frame(width: 40, height: 40)
+                    .padding(.bottom, -30.adjustedHeight)
+                    .padding(.leading, 16.adjustedWidth)
+                Spacer()
+            }
+            .zIndex(10)
+
+            Color.clear
+                .frame(height: 52.adjusted)
+                .padding(.bottom, isSEDevice ? 24 : 14.adjusted)
+            Color.clear
+                .frame(height: 370.adjusted)
+                .padding(.bottom, isSEDevice ? 15 : 20.adjusted)
+                .padding(.horizontal, isSEDevice ? 28 : 32.adjustedWidth)
+            Color.clear
+                .frame(height: 52)
+                .padding(.bottom, 12.adjusted)
+                .padding(.horizontal, isSEDevice ? 28 : 32.adjustedWidth)
+
+            actionButtonView
+                .padding(.horizontal, isSEDevice ? 28 : 32.adjustedWidth)
+                .padding(.bottom, 23.adjustedHeight)
+        }
+        .padding(.top, isSEDevice ? 16 : 54.adjustedHeight)
+    }
+
+    /// 코치마크 안내 텍스트 + CTA — 화면 중앙 정렬
+    private func coachMarkText(
+        headline: String,
+        subtitle: String,
+        buttonTitle: String,
+        accessibilityLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 12.adjusted) {
+            Text(headline)
+                .font(.neoDunggeunmo22)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.textHeadlinePrimary)
+
+            Text(subtitle)
+                .font(.body1_regular16)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.textBodyTeritary)
+
+            GreenButton(action: action, title: buttonTitle, disabled: false)
+                .frame(width: 120)
+                .accessibilityLabel(accessibilityLabel)
+                .padding(.top, 16.adjusted)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .transition(.opacity)
     }
     
     private var petImageScale: CGFloat {

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -53,6 +53,10 @@ final class HomeViewModel: ObservableObject {
     @Published var enableRandomPet: Bool = false
     @Published var showRandomPetGuide: Bool = false
     @Published var showRandomGachaView: Bool = false
+
+    /// 홈 진입 코치마크 (먹이주기 → 놀아주기 순서)
+    @Published var showFeedCoachMark: Bool = false
+    @Published var showPlayCoachMark: Bool = false
     
     let homeRepository: HomeRepositoryProtocol
     
@@ -335,15 +339,46 @@ final class HomeViewModel: ObservableObject {
         withAnimation {
             enableRandomPet = true
         }
-        
+
         // 최대 레벨에서 돌아올 때 체크
         if UserDefaultValue.isFirstRandomTicket {
             UserDefaultValue.isFirstRandomTicket = false
-            
+
            // 첫 랜덤 가챠일 경우 표출
             withAnimation(.easeInOut(duration: 0.6)) {
                 showRandomPetGuide = true
             }
+        }
+    }
+
+    /// 홈 진입 시 신규 사용자에게 먹이/놀이 코치마크 시작.
+    /// 가챠 코치마크와 동시 노출되지 않도록 가드.
+    @MainActor
+    func startHomeCoachMarkIfNeeded() {
+        guard UserDefaultValue.isFirstHomeCoachMarkShown else { return }
+        guard !showRandomPetGuide else { return }
+        UserDefaultValue.isFirstHomeCoachMarkShown = false
+        withAnimation(.easeInOut(duration: 0.6)) {
+            showFeedCoachMark = true
+        }
+    }
+
+    /// "다음" → 먹이 코치마크 닫고 놀이 코치마크 노출
+    @MainActor
+    func tapFeedCoachMarkNext() {
+        AnalyticsManager.shared.logEvent(event: HomeEvent.clickFeedCoachMarkNext)
+        withAnimation(.easeInOut(duration: 0.6)) {
+            showFeedCoachMark = false
+            showPlayCoachMark = true
+        }
+    }
+
+    /// "시작하기" → 놀이 코치마크 닫기. 추가 동작 없음.
+    @MainActor
+    func tapPlayCoachMarkStart() {
+        AnalyticsManager.shared.logEvent(event: HomeEvent.clickPlayCoachMarkStart)
+        withAnimation(.easeInOut(duration: 0.6)) {
+            showPlayCoachMark = false
         }
     }
     

--- a/DDanDDan/Util/AnalyticsManager.swift
+++ b/DDanDDan/Util/AnalyticsManager.swift
@@ -126,15 +126,19 @@ enum HomeEvent: AnalyticsEvent {
     case clickPlayBtn
     case clickCancelBtn(path: String = "select-egg")
     case clickBtn(path: String = "select-egg")
+    case clickFeedCoachMarkNext
+    case clickPlayCoachMarkStart
 
     var title: String {
         switch self {
-        case .clickNewPetBtn: return "click_new_pet_btn"
-        case .clickPet:       return "click_pet"
-        case .clickFeedBtn:   return "click_feed_btn"
-        case .clickPlayBtn:   return "click_play_btn"
-        case .clickCancelBtn: return "click_cancel_btn"
-        case .clickBtn:       return "click_btn"
+        case .clickNewPetBtn:          return "click_new_pet_btn"
+        case .clickPet:                return "click_pet"
+        case .clickFeedBtn:            return "click_feed_btn"
+        case .clickPlayBtn:            return "click_play_btn"
+        case .clickCancelBtn:          return "click_cancel_btn"
+        case .clickBtn:                return "click_btn"
+        case .clickFeedCoachMarkNext:  return "click_feed_coachmark_next"
+        case .clickPlayCoachMarkStart: return "click_play_coachmark_start"
         }
     }
 

--- a/DDanDDan/Util/UserDefaultValue.swift
+++ b/DDanDDan/Util/UserDefaultValue.swift
@@ -53,6 +53,9 @@ public struct UserDefaultValue {
     @UserDefault(key: "isFirstRandomTicket", defaultValue: true)
     static public var isFirstRandomTicket: Bool
 
+    @UserDefault(key: "isFirstHomeCoachMarkShown", defaultValue: true)
+    static public var isFirstHomeCoachMarkShown: Bool
+
     // 강제 업데이트 캐시
     @UserDefault(key: "cachedMinimumVersion", defaultValue: nil)
     static public var cachedMinimumVersion: String?


### PR DESCRIPTION
## Summary
- 신규 사용자가 홈에 처음 진입했을 때 핵심 액션 두 가지(`먹이주기`, `놀아주기`)를 순차로 안내하는 코치마크를 추가.
- 기존 `showRandomPetGuide`의 dim + spotlight 패턴을 두 단계로 확장하되, **HomeButton은 단일 source of truth로 한 번만 렌더**되도록 구조화 (메인 VStack의 자리는 `Color.clear` placeholder로 예약, 실제 렌더링은 dim 위 `actionButtonsLayer`).
- `isFirstHomeCoachMarkShown` 플래그로 1회만 노출.

## 동작
1. 첫 홈 진입 → 먹이 안내 + 좌측 `먹이주기` spotlight, "다음" 탭
2. 놀이 안내 + 우측 `놀아주기` spotlight, "시작하기" 탭
3. 코치마크 닫힘. 다음 앱 실행부터는 표시되지 않음.
4. 가챠 코치마크(`showRandomPetGuide`)와 동시 노출 가드 포함.

## 변경 파일
- `DDanDDan/Util/UserDefaultValue.swift` — `isFirstHomeCoachMarkShown` 플래그 1개 추가
- `DDanDDan/Presenter/Home/HomeViewModel.swift` — `showFeedCoachMark` / `showPlayCoachMark` Published + 3개 메소드 (시작/다음/시작하기)
- `DDanDDan/Presenter/Home/HomeView.swift` — \`actionButtonsLayer\` (메인 VStack 미러) + \`coachMarkText\` (중앙 안내) + \`actionButtonView\` 자체에 코치마크 상태 반영(shadow/opacity)
- `DDanDDan/Util/AnalyticsManager.swift` — \`clickFeedCoachMarkNext\`, \`clickPlayCoachMarkStart\` 이벤트 추가

## 알려진 한계 / 후속
- 곡선 화살표 Asset(\`imgGuideArrowLeft/Right\`)은 디자이너 입수 후 별도 작업 (TODO 주석)
- \`isFirstHomeCoachMarkShown\` 기본값 \`true\`라 기존 사용자도 다음 앱 실행 시 1회 노출됨. 신규 가입자만 노출하려면 회원가입 완료 시점에 명시 set 후 default \`false\`로 변경 필요
- 안내 노출 중 spotlight HomeButton 자체 탭은 무동작 (CTA로만 진행)

## Test plan
- [ ] 시뮬레이터 앱 데이터 삭제 → 온보딩/로그인 → 홈 진입 시 첫 가이드(먹이주기) 노출
- [ ] dim + 좌측 먹이주기 spotlight, 우측 놀아주기 opacity 0.3 시각 확인
- [ ] "다음" 탭 → 두 번째 가이드(놀아주기)로 전환, spotlight 좌↔우 반전
- [ ] "시작하기" 탭 → 가이드 닫힘, 정상 홈 사용
- [ ] 앱 재실행 시 가이드 안 뜸 확인
- [ ] 기존 가챠 코치마크와 동시 노출되지 않는지 확인 (레벨 5 도달 후)
- [ ] iPhone SE 등 작은 기기 레이아웃 깨짐 없음 확인
- [ ] Firebase Analytics DebugView에서 \`click_feed_coachmark_next\`, \`click_play_coachmark_start\` 이벤트 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 홈 화면 신규 사용자 가이드 추가 - 피드와 플레이 기능을 소개하는 코칭 마크 오버레이가 첫 사용 시 표시되며, 사용자는 단계적으로 각 섹션을 탐색할 수 있습니다.

## 기타
* 가이드 기능 사용자 상호작용에 대한 분석 이벤트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->