### PR TITLE
feat: Pet Catalog SVG 다운로드 마이그레이션 인프라 (PR 1/4)

### DIFF
--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -152,6 +152,9 @@
 		36F6E81F2CEE7B4900B395FB /* NavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E81E2CEE7B4900B395FB /* NavigationBarView.swift */; };
 		36F6E8212CEE7DE000B395FB /* CheckButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E8202CEE7DE000B395FB /* CheckButton.swift */; };
 		36F6E8232CEE8F0B00B395FB /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E8222CEE8F0B00B395FB /* String+.swift */; };
+		5416D1439ADD5D43B7518D46 /* PetCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFABC97C4956364FC9830AC /* PetCatalog.swift */; };
+		A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430817BD29DFEF1965C8A57F /* PetAssetCache.swift */; };
+		C9D8EED051CEED09043E7CC9 /* PetCatalogNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */; };
 		F809E2FA2CBD05F5001BE099 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2F92CBD05F5001BE099 /* UserData.swift */; };
 		F809E2FC2CBD06A1001BE099 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2FB2CBD06A1001BE099 /* UserManager.swift */; };
 		F809E2FE2CBD0841001BE099 /* DeleteUserConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2FD2CBD0841001BE099 /* DeleteUserConfirmView.swift */; };
@@ -307,6 +310,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0CFABC97C4956364FC9830AC /* PetCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalog.swift; sourceTree = "<group>"; };
 		36022B722CCAA04000D360C0 /* HomeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeButton.swift; sourceTree = "<group>"; };
 		360E6B352CEBC5F10059661E /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		360E6B372CEBC8A60059661E /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
@@ -444,6 +448,8 @@
 		36F6E81E2CEE7B4900B395FB /* NavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarView.swift; sourceTree = "<group>"; };
 		36F6E8202CEE7DE000B395FB /* CheckButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckButton.swift; sourceTree = "<group>"; };
 		36F6E8222CEE8F0B00B395FB /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		430817BD29DFEF1965C8A57F /* PetAssetCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetAssetCache.swift; sourceTree = "<group>"; };
+		EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogNetwork.swift; sourceTree = "<group>"; };
 		F809E2F92CBD05F5001BE099 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		F809E2FB2CBD06A1001BE099 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		F809E2FD2CBD0841001BE099 /* DeleteUserConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteUserConfirmView.swift; sourceTree = "<group>"; };
@@ -501,14 +507,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		36A9D7222DE9A20400A9169A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		36A9D7222DE9A20400A9169A /* Exceptions for "DDanDDan_Widget" folder in "DDanDDan_WidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = 36A9D70D2DE9A20300A9169A /* DDanDDan_WidgetExtension */;
 		};
-		36A9D7442DED8D7500A9169A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		36A9D7442DED8D7500A9169A /* Exceptions for "DDanDDan_WatchWidget" folder in "DDanDDan_WatchWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -518,8 +524,30 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		36A9D7112DE9A20300A9169A /* DDanDDan_Widget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (36A9D7222DE9A20400A9169A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = DDanDDan_Widget; sourceTree = "<group>"; };
-		36A9D7392DED8D7400A9169A /* DDanDDan_WatchWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (36A9D7442DED8D7500A9169A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = DDanDDan_WatchWidget; sourceTree = "<group>"; };
+		36A9D7112DE9A20300A9169A /* DDanDDan_Widget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				36A9D7222DE9A20400A9169A /* Exceptions for "DDanDDan_Widget" folder in "DDanDDan_WidgetExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = DDanDDan_Widget;
+			sourceTree = "<group>";
+		};
+		36A9D7392DED8D7400A9169A /* DDanDDan_WatchWidget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				36A9D7442DED8D7500A9169A /* Exceptions for "DDanDDan_WatchWidget" folder in "DDanDDan_WatchWidgetExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = DDanDDan_WatchWidget;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1014,6 +1042,7 @@
 				364195A62D72F0430065C400 /* RankNetwork.swift */,
 				F9A845A92E862BD10021D0FE /* CheerNetwork.swift */,
 				36BC7D012E82E959002B1ED5 /* FriendNetwork.swift */,
+				EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1045,6 +1074,7 @@
 				F88FC6DE2CCF3BF70033D4C9 /* Pet.swift */,
 				F88FC6E02CCF64150033D4C9 /* MainPet.swift */,
 				367A796C2CDCB30A0055771B /* PetArchiveModel.swift */,
+				0CFABC97C4956364FC9830AC /* PetCatalog.swift */,
 			);
 			path = Pet;
 			sourceTree = "<group>";
@@ -1061,6 +1091,7 @@
 				F85C2BA32C4CD651002E2237 /* UserDefaultValue.swift */,
 				F9AF64F42E38639300FE6777 /* RemoteConfigManager.swift */,
 				363CC4472CCADC6A00D2EE47 /* WatchConnectivityManager.swift */,
+				430817BD29DFEF1965C8A57F /* PetAssetCache.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1202,8 +1233,6 @@
 				36A9D7112DE9A20300A9169A /* DDanDDan_Widget */,
 			);
 			name = DDanDDan_WidgetExtension;
-			packageProductDependencies = (
-			);
 			productName = DDanDDan_WidgetExtension;
 			productReference = 36A9D70E2DE9A20300A9169A /* DDanDDan_WidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -1224,8 +1253,6 @@
 				36A9D7392DED8D7400A9169A /* DDanDDan_WatchWidget */,
 			);
 			name = DDanDDan_WatchWidgetExtension;
-			packageProductDependencies = (
-			);
 			productName = DDanDDan_WatchWidgetExtension;
 			productReference = 36A9D7362DED8D7400A9169A /* DDanDDan_WatchWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -1245,8 +1272,6 @@
 				36A9D7422DED8D7500A9169A /* PBXTargetDependency */,
 			);
 			name = "DdanDdan_Watch Watch App";
-			packageProductDependencies = (
-			);
 			productName = "DdanDdan_Watch Watch App";
 			productReference = 36E0196C2CCA830A00383318 /* DdanDdan_Watch Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -1265,8 +1290,6 @@
 				36E0197D2CCA830C00383318 /* PBXTargetDependency */,
 			);
 			name = "DdanDdan_Watch Watch AppTests";
-			packageProductDependencies = (
-			);
 			productName = "DdanDdan_Watch Watch AppTests";
 			productReference = 36E0197B2CCA830C00383318 /* DdanDdan_Watch Watch AppTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -1285,8 +1308,6 @@
 				36E019872CCA830C00383318 /* PBXTargetDependency */,
 			);
 			name = "DdanDdan_Watch Watch AppUITests";
-			packageProductDependencies = (
-			);
 			productName = "DdanDdan_Watch Watch AppUITests";
 			productReference = 36E019852CCA830C00383318 /* DdanDdan_Watch Watch AppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -1683,6 +1704,9 @@
 				36465DAC2CFA415200784E8A /* LottieString.swift in Sources */,
 				36F6E8212CEE7DE000B395FB /* CheckButton.swift in Sources */,
 				367A796F2CDCBC210055771B /* PathString.swift in Sources */,
+				5416D1439ADD5D43B7518D46 /* PetCatalog.swift in Sources */,
+				C9D8EED051CEED09043E7CC9 /* PetCatalogNetwork.swift in Sources */,
+				A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DDanDDan/Entity/Pet/PetCatalog.swift
+++ b/DDanDDan/Entity/Pet/PetCatalog.swift
@@ -1,0 +1,35 @@
+//
+//  PetCatalog.swift
+//  DDanDDan
+//
+//  Created by mark.dd on 2026-05-12.
+//
+
+import Foundation
+
+public struct PetCatalog: Codable, Equatable {
+    public let version: String
+    public let pets: [PetCatalogItem]
+}
+
+public struct PetCatalogItem: Codable, Equatable {
+    public let type: String
+    public let name: String
+    public let displayOrder: Int
+    public let isActive: Bool
+    // 키 "1"~"5" 등 레벨 문자열. Int 키 변환은 후속 Repository에서 수행.
+    public let levels: [String: PetCatalogLevel]
+    public let backgrounds: PetCatalogBackgrounds
+}
+
+public struct PetCatalogLevel: Codable, Equatable {
+    public let imageUrl: String
+    public let lottieDefaultUrl: String
+    public let lottiePlayEatUrl: String
+}
+
+public struct PetCatalogBackgrounds: Codable, Equatable {
+    public let homeUrl: String
+    public let homeCompactUrl: String
+    public let friendCardUrl: String
+}

--- a/DDanDDan/Network/PathString.swift
+++ b/DDanDDan/Network/PathString.swift
@@ -13,6 +13,7 @@ enum PathString {
         static let userPets = "/v1/pets/me"
         static let randomPet = "/v1/pets/me/random"
         static let randomGachaPet = "/v1/pets/me/gacha"
+        static let catalog = "/v1/pets/catalog"
     }
     
     enum User {

--- a/DDanDDan/Network/PetCatalogNetwork.swift
+++ b/DDanDDan/Network/PetCatalogNetwork.swift
@@ -37,15 +37,21 @@ public struct PetCatalogNetwork {
             headers["X-iOS-Version"] = appVersion
         }
 
+        // 토큰 노출 방지: Authorization 값을 redact한 사본만 로깅/Analytics로 전달.
+        var sanitizedHeaders = headers
+        if sanitizedHeaders["Authorization"] != nil {
+            sanitizedHeaders["Authorization"] = "Bearer <redacted>"
+        }
+
         print("\n📡 Request:")
         print("🔹 URL: \(url)")
         print("🔹 Method: GET")
-        print("🔹 Headers: \(headers)")
+        print("🔹 Headers: \(sanitizedHeaders)")
 
         AnalyticsManager.shared.logEvent(
             event: NetworkEvent.request(
                 url: url.absoluteString,
-                header: headers.description,
+                header: sanitizedHeaders.description,
                 params: nil
             )
         )

--- a/DDanDDan/Network/PetCatalogNetwork.swift
+++ b/DDanDDan/Network/PetCatalogNetwork.swift
@@ -1,0 +1,126 @@
+//
+//  PetCatalogNetwork.swift
+//  DDanDDan
+//
+//  Created by mark.dd on 2026-05-12.
+//
+
+import Foundation
+import Alamofire
+
+// TODO: 헤더(X-Pet-Catalog-Version) 노출 필요로 NetworkManager 미사용.
+// 후속 PR에서 NetworkManager에 헤더 반환 API 통합 검토.
+public struct PetCatalogNetwork {
+    private let baseURL = Config.baseURL
+    private let session: Session
+
+    public init() {
+        let config = URLSessionConfiguration.default
+        config.requestCachePolicy = .useProtocolCachePolicy
+        self.session = Session(configuration: config, interceptor: TokenInterceptor())
+    }
+
+    /// 펫 카탈로그를 조회한다.
+    /// - Returns: 성공 시 디코딩된 `PetCatalog` 와 응답 헤더 `X-Pet-Catalog-Version` 값(없으면 nil).
+    public func fetchCatalog() async -> Result<(catalog: PetCatalog, version: String?), NetworkError> {
+        guard let url = URL(string: baseURL + PathString.Pet.catalog) else {
+            return .failure(NetworkError.urlError)
+        }
+
+        var headers: HTTPHeaders = [
+            "Content-Type": "application/json"
+        ]
+        if let accessToken = UserDefaultValue.accessToken {
+            headers["Authorization"] = "Bearer \(accessToken)"
+        }
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            headers["X-iOS-Version"] = appVersion
+        }
+
+        print("\n📡 Request:")
+        print("🔹 URL: \(url)")
+        print("🔹 Method: GET")
+        print("🔹 Headers: \(headers)")
+
+        AnalyticsManager.shared.logEvent(
+            event: NetworkEvent.request(
+                url: url.absoluteString,
+                header: headers.description,
+                params: nil
+            )
+        )
+
+        // NetworkManager와 동일하게 401까지 valid로 두어 TokenInterceptor retry 위임.
+        let dataTask = session.request(url, method: .get, headers: headers)
+            .validate(statusCode: 200..<401)
+        let result = await dataTask.serializingData().response
+
+        print("\n📥 Response:")
+        if let error = result.error {
+            print("🔹 AFError: \(error.localizedDescription)")
+
+            if let statusCode = error.responseCode {
+                if let data = result.data {
+                    do {
+                        let errorResponse = try JSONDecoder().decode(ServerErrorResponse.self, from: data)
+                        print("🔹 Server Error Code: \(errorResponse.code)")
+                        print("🔹 Server Error Message: \(errorResponse.message)")
+                        AnalyticsManager.shared.logEvent(event: NetworkEvent.onError(errorResponse))
+                        return .failure(NetworkError.serverError(statusCode, errorResponse.code))
+                    } catch {
+                        return .failure(NetworkError.failToDecode(error.localizedDescription))
+                    }
+                } else {
+                    print("🔹 Server Error: No data available")
+                    return .failure(NetworkError.serverError(statusCode, "Unknown error"))
+                }
+            }
+
+            return .failure(NetworkError.requestFailed(error.errorDescription ?? "Unknown error"))
+        }
+
+        guard let response = result.response else {
+            print("🔹 Error: Invalid response")
+            return .failure(NetworkError.invalidResponse)
+        }
+
+        print("🔹 Status Code: \(response.statusCode)")
+
+        // 400은 validate(200..<401)에서 valid로 흘러내려 오므로 NetworkManager와 동일하게 본문에서 ServerErrorResponse를 분리 디코드.
+        if response.statusCode == 400 {
+            guard let data = result.data else {
+                return .failure(NetworkError.dataNil)
+            }
+
+            do {
+                let errorResponse = try JSONDecoder().decode(ServerErrorResponse.self, from: data)
+                print("🔹 400 Error - Code: \(errorResponse.code), Message: \(errorResponse.message)")
+                AnalyticsManager.shared.logEvent(event: NetworkEvent.onError(errorResponse))
+                return .failure(NetworkError.serverError(400, errorResponse.code))
+            } catch {
+                print("🔹 400 Decoding Error: \(error.localizedDescription)")
+                return .failure(NetworkError.failToDecode(error.localizedDescription))
+            }
+        }
+
+        if 200..<300 ~= response.statusCode {
+            guard let data = result.data, !data.isEmpty else {
+                return .failure(NetworkError.dataNil)
+            }
+
+            do {
+                let catalog = try JSONDecoder().decode(PetCatalog.self, from: data)
+                // HTTPURLResponse.value(forHTTPHeaderField:) 는 case-insensitive.
+                let version = response.value(forHTTPHeaderField: "X-Pet-Catalog-Version")
+                print("🔹 Success: catalog version header = \(version ?? "nil"), body version = \(catalog.version)")
+                return .success((catalog: catalog, version: version))
+            } catch {
+                print("🔹 Decoding Error: \(error.localizedDescription)")
+                return .failure(NetworkError.failToDecode(error.localizedDescription))
+            }
+        } else {
+            print("🔹 Server Error: \(response.statusCode)")
+            return .failure(NetworkError.serverError(response.statusCode, response.description))
+        }
+    }
+}

--- a/DDanDDan/Util/PetAssetCache.swift
+++ b/DDanDDan/Util/PetAssetCache.swift
@@ -88,8 +88,13 @@ public actor PetAssetCache {
         }
     }
 
-    /// 메모리 + 디스크 캐시 전체 비우기.
+    /// 메모리 + 디스크 캐시 전체 비우기. 진행 중 다운로드 Task도 함께 cancel하여
+    /// clear 직후 inflight 완료분이 캐시를 재오염시키는 것을 막는다.
     public func clear() async {
+        for (_, task) in inflight {
+            task.cancel()
+        }
+        inflight.removeAll()
         memory.removeAllObjects()
         let fm = FileManager.default
         if let items = try? fm.contentsOfDirectory(at: diskRoot, includingPropertiesForKeys: nil) {

--- a/DDanDDan/Util/PetAssetCache.swift
+++ b/DDanDDan/Util/PetAssetCache.swift
@@ -1,0 +1,117 @@
+//
+//  PetAssetCache.swift
+//  DDanDDan
+//
+//  Created by mark.dd on 2026-05-12.
+//
+
+import Foundation
+import UIKit
+import CryptoKit
+// TODO: SVGKit SPM 추가 후 decode() 및 import 활성화 — 02_implementer_changes.md [B1] 참조.
+// import SVGKit
+
+/// 펫 이미지(SVG/PNG/JPEG) 메모리 + 디스크 캐시.
+/// App Group `group.com.DdanDdan` 컨테이너 `pet-assets/` 디렉토리에 sha256 hex 파일명으로 저장한다.
+public actor PetAssetCache {
+    public static let shared = PetAssetCache(appGroup: "group.com.DdanDdan")
+
+    private let memory = NSCache<NSString, UIImage>()
+    private let diskRoot: URL
+    private var inflight: [URL: Task<UIImage?, Never>] = [:]
+
+    public init(appGroup: String) {
+        let fm = FileManager.default
+        let baseURL: URL
+        if let containerURL = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+            baseURL = containerURL.appendingPathComponent("pet-assets", isDirectory: true)
+        } else {
+            // App Group 컨테이너 접근 실패 시 안전 폴백 — crash 금지.
+            // 임시 디렉토리는 OS가 정리할 수 있으나, 적어도 컴파일/런타임은 통과.
+            // 운영 가시성을 위해 로그를 남긴다 — 타겟 간 캐시 공유가 깨진 신호.
+            print("⚠️ PetAssetCache: App Group '\(appGroup)' container missing — fallback to temporaryDirectory")
+            baseURL = fm.temporaryDirectory.appendingPathComponent("pet-assets", isDirectory: true)
+        }
+        self.diskRoot = baseURL
+        try? fm.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    }
+
+    /// 단일 URL에 대한 이미지 획득. 메모리 → 디스크 → 네트워크 순서.
+    public func image(for url: URL) async -> UIImage? {
+        // 1) 메모리 hit
+        if let cached = memory.object(forKey: url.absoluteString as NSString) {
+            return cached
+        }
+
+        // 2) 동일 URL inflight 공유 (dedup)
+        if let task = inflight[url] {
+            return await task.value
+        }
+
+        // 3) 새 Task 등록. actor self 캡처 피하기 위해 stored property만 캡처.
+        let diskRoot = self.diskRoot
+        let memory = self.memory
+        let task = Task<UIImage?, Never> {
+            let filename = Self.sha256Hex(url.absoluteString)
+            let diskURL = diskRoot.appendingPathComponent(filename)
+
+            // 3-a) 디스크 hit
+            if let data = try? Data(contentsOf: diskURL), let img = Self.decode(data: data) {
+                memory.setObject(img, forKey: url.absoluteString as NSString)
+                return img
+            }
+
+            // 3-b) 네트워크 fetch → 디스크 write → 메모리 write
+            guard let (data, _) = try? await URLSession.shared.data(from: url),
+                  let img = Self.decode(data: data) else {
+                return nil
+            }
+            try? data.write(to: diskURL, options: .atomic)
+            memory.setObject(img, forKey: url.absoluteString as NSString)
+            return img
+        }
+
+        inflight[url] = task
+        let result = await task.value
+        inflight[url] = nil
+        return result
+    }
+
+    /// 다수 URL 사전 적재. 결과는 버리고 캐시에만 채운다.
+    public func prefetch(urls: [URL]) async {
+        await withTaskGroup(of: Void.self) { group in
+            for url in urls {
+                group.addTask { [weak self] in
+                    _ = await self?.image(for: url)
+                }
+            }
+        }
+    }
+
+    /// 메모리 + 디스크 캐시 전체 비우기.
+    public func clear() async {
+        memory.removeAllObjects()
+        let fm = FileManager.default
+        if let items = try? fm.contentsOfDirectory(at: diskRoot, includingPropertiesForKeys: nil) {
+            for item in items {
+                try? fm.removeItem(at: item)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// SVG 우선 → UIImage 폴백. 현재 SVGKit 미등록으로 UIImage 폴백만 동작.
+    private static func decode(data: Data) -> UIImage? {
+        // TODO: SVGKit SPM 추가 후 아래 블록 활성화.
+        // if let svg = SVGKImage(data: data), let img = svg.uiImage {
+        //     return img
+        // }
+        return UIImage(data: data)
+    }
+
+    private static func sha256Hex(_ string: String) -> String {
+        let digest = SHA256.hash(data: Data(string.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/DdanDdan_Watch Watch App/DdanDdan_Watch Watch App.entitlements
+++ b/DdanDdan_Watch Watch App/DdanDdan_Watch Watch App.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.developer.healthkit.background-delivery</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.DdanDdan</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 배경

서버(`ddan-ddan-server`)가 펫 에셋을 정적 번들 의존에서 동적 카탈로그 API(`GET /v1/pets/catalog`)로 전환. iOS 클라이언트는 단계적 마이그레이션 진행 중이며 **본 PR은 1단계: 수신/캐싱 인프라만 도입**한다. 호출처(View/ViewModel/Widget/Watch) 변경은 PR 2부터.

## 산출물

### 신규
- `DDanDDan/Entity/Pet/PetCatalog.swift` — 서버 DTO 1:1 매핑 (`PetCatalog`, `PetCatalogItem`, `PetCatalogLevel`, `PetCatalogBackgrounds`). 모두 `Codable, Equatable, public`.
- `DDanDDan/Network/PetCatalogNetwork.swift` — `fetchCatalog() async -> Result<(PetCatalog, version: String?), NetworkError>`. 응답 헤더 `X-Pet-Catalog-Version` 추출. Alamofire 직접 사용 + `TokenInterceptor` 재사용. 400 응답은 `ServerErrorResponse` 디코드 분기로 처리(NetworkManager와 동일 패턴).
- `DDanDDan/Util/PetAssetCache.swift` — `actor`. 메모리(`NSCache`) + 디스크(`group.com.DdanDdan` 공유 컨테이너 `pet-assets/`, sha256 hex 파일명) 2단 캐시. 동일 URL 동시 요청은 in-flight `Task` 공유로 dedup. App Group 접근 실패 시 `temporaryDirectory` 폴백 + 로그.

### 수정
- `DDanDDan/Network/PathString.swift` — `Pet.catalog = \"/v1/pets/catalog\"` 추가.
- `DdanDdan_Watch Watch App/DdanDdan_Watch Watch App.entitlements` — `com.apple.security.application-groups`에 `group.com.DdanDdan` 추가(메인/Widget은 기존부터 존재).
- `DDanDDan.xcodeproj/project.pbxproj` — 신규 3 파일을 `DDanDDan` 메인 타겟에 등록.

## 작업 내용

1. 카탈로그 응답 수신용 형 안전 DTO 도입.
2. 응답 헤더 `X-Pet-Catalog-Version`을 통한 캐시 invalidation을 지원하기 위한 헤더 노출 API 추가(현재 `NetworkManager`는 본문만 반환). 단발성 필요라 `NetworkManager` 공용 시그니처 확장 대신 별도 파일로 분리.
3. 메모리 + 디스크 2단 캐시 + actor 동시성 + dedup 패턴 구현. Widget/Watch 멤버십은 PR 4에서 확장.
4. 다음 PR 2의 `PetCatalogRepository`가 본 인프라를 호출할 예정.

## 검증

빌드/런타임 검증을 모두 통과(`/Users/ddingmin/.claude/plans/ios-lovely-muffin.md`의 검증 계획 따름).

- **메인 앱** (iPhone 17 Pro / iOS 26.3 sim, Debug): 빌드 SUCCEEDED, 앱 설치/런치 후 로그인 화면 정상 부팅, 크래시 없음
- **Widget extension**: 빌드 SUCCEEDED
- **Watch app** (Apple Watch Series 11 / watchOS 26.2 sim): 빌드 SUCCEEDED
- DerivedData에 `PetCatalog.o`, `PetCatalogNetwork.o`, `PetAssetCache.o` 산출물 생성 확인

## 머지 전 사용자 체크리스트

- [ ] 본 PR은 dormant infra (아무도 호출 안 함) — 회귀 0건. 메인 화면 1회 부팅으로 충분.
- [ ] Release archive 전 [Apple Developer Portal](https://developer.apple.com/account/resources/identifiers/list) → Watch App ID에 **App Groups** capability 활성화 + `group.com.DdanDdan` 체크 (시뮬레이터 빌드는 통과해도 codesign 단계에서 fail 가능).

## 후속 PR로 인계

1. **SVGKit SPM 추가 + `PetAssetCache.decode()` SVGKImage 경로 활성화** — PR 2 첫 단계. 현재는 `UIImage(data:)` 폴백만 사용(서버가 임시로 PNG 내려보내는 동안 정상).
2. **`PetCatalogRepository` + sync 트리거 + HomeView 전환** — PR 2.
3. **PetArchive / Friends / Rank / LevelUp 호출처 일괄 전환** — PR 3.
4. **Widget / Watch TimelineProvider / ViewModel 전환** — PR 4. PetAssetCache의 Widget/Watch 타겟 멤버십 확장.
5. **`NetworkManager.requestWithHeaders<T>` 통합** — PetCatalogNetwork 중복 ~50줄 정리.
6. **TokenInterceptor 일원화** — 신규 네트워크 코드에서 수동 `Authorization` 주입 제거.
7. **메인 앱 테스트 타겟 신설** — `PetAssetCacheTests` / `PetCatalogNetworkTests` 추가를 위한 `DDanDDanTests` 신설.

## 자체 리뷰 결과

ios-architect → swift-implementer → swift-reviewer → swift-tester(XcodeBuildMCP MCP) → swift-reviewer 반영의 5단계 자체 리뷰 후 종합 판정 **Pass with minor**. 상세는 `_workspace/`(미커밋) 산출물에 보존:

- Major 1건(400 응답 ServerErrorResponse 디코드 분기 누락) 해소
- Minor 2건(폴백 로깅, validate range 의도 주석) 반영
- 그 외 Minor/Nit는 후속 인계

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 반려동물 카탈로그 기능(버전 포함) 추가 및 카탈로그 조회용 네트워크 엔드포인트 제공
  * 반려동물 자산 캐시 추가(메모리·디스크·네트워크, 프리페치/삭제 지원)로 이미지 로딩 성능 향상
* **설정/구성**
  * 앱 그룹 권한 추가로 공유 캐시 디렉터리 지원

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ddan-dda-ra/ddan-ddan-ios/pull/66)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ddan-dda-ra/ddan-ddan-ios/pull/66)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->