### PR TITLE
feat: PetCatalogRepository + sync 트리거 + LevelUpView 첫 전환 (PR 2/4)

### DIFF
--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -153,7 +153,9 @@
 		36F6E8212CEE7DE000B395FB /* CheckButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E8202CEE7DE000B395FB /* CheckButton.swift */; };
 		36F6E8232CEE8F0B00B395FB /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E8222CEE8F0B00B395FB /* String+.swift */; };
 		5416D1439ADD5D43B7518D46 /* PetCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFABC97C4956364FC9830AC /* PetCatalog.swift */; };
+		89231B8EB906A4F93EB1B741 /* PetCatalogRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D18791ED1B8229F0B20590 /* PetCatalogRepository.swift */; };
 		A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430817BD29DFEF1965C8A57F /* PetAssetCache.swift */; };
+		B971C715158ECDA6DEC8C3EC /* PetImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031CEB03B7B20E51DB83D877 /* PetImageView.swift */; };
 		C9D8EED051CEED09043E7CC9 /* PetCatalogNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */; };
 		F809E2FA2CBD05F5001BE099 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2F92CBD05F5001BE099 /* UserData.swift */; };
 		F809E2FC2CBD06A1001BE099 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2FB2CBD06A1001BE099 /* UserManager.swift */; };
@@ -310,6 +312,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		031CEB03B7B20E51DB83D877 /* PetImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetImageView.swift; sourceTree = "<group>"; };
 		0CFABC97C4956364FC9830AC /* PetCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalog.swift; sourceTree = "<group>"; };
 		36022B722CCAA04000D360C0 /* HomeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeButton.swift; sourceTree = "<group>"; };
 		360E6B352CEBC5F10059661E /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -449,6 +452,7 @@
 		36F6E8202CEE7DE000B395FB /* CheckButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckButton.swift; sourceTree = "<group>"; };
 		36F6E8222CEE8F0B00B395FB /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		430817BD29DFEF1965C8A57F /* PetAssetCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetAssetCache.swift; sourceTree = "<group>"; };
+		E7D18791ED1B8229F0B20590 /* PetCatalogRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogRepository.swift; sourceTree = "<group>"; };
 		EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogNetwork.swift; sourceTree = "<group>"; };
 		F809E2F92CBD05F5001BE099 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		F809E2FB2CBD06A1001BE099 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
@@ -787,6 +791,7 @@
 				369F16F42D8707E50039ED3A /* RankRepository.swift */,
 				36BC7D062E82EA7D002B1ED5 /* FriendRepository.swift */,
 				F9BCC0AE2E8227AC0035E1AF /* FriendCardRepository.swift */,
+				E7D18791ED1B8229F0B20590 /* PetCatalogRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -958,6 +963,7 @@
 				369F16F82D99A3850039ED3A /* CustomScrollView.swift */,
 				36A9D6EF2DE5E41800A9169A /* SwipeBackEnabledModifier.swift */,
 				36CAE0E32E6B160900B81039 /* ButtonStyles.swift */,
+				031CEB03B7B20E51DB83D877 /* PetImageView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1707,6 +1713,8 @@
 				5416D1439ADD5D43B7518D46 /* PetCatalog.swift in Sources */,
 				C9D8EED051CEED09043E7CC9 /* PetCatalogNetwork.swift in Sources */,
 				A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */,
+				89231B8EB906A4F93EB1B741 /* PetCatalogRepository.swift in Sources */,
+				B971C715158ECDA6DEC8C3EC /* PetImageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DDanDDan/DDanDDanApp.swift
+++ b/DDanDDan/DDanDDanApp.swift
@@ -27,6 +27,8 @@ struct DDanDDanApp: App {
     
     init() {
         KakaoSDK.initSDK(appKey: Config.kakaoKey)
+        // T1) 콜드 스타트 시 펫 카탈로그 sync (fire-and-forget). TTL/dedup 는 Repository 내부.
+        Task { try? await PetCatalogRepository.liveValue.syncIfNeeded() }
     }
     
     var body: some Scene {
@@ -193,6 +195,8 @@ struct ContentView: View {
     @EnvironmentObject var coordinator: AppCoordinator
     @EnvironmentObject var user: UserManager
     @State private var mainTabStore = Store(initialState: MainTabReducer.State()) { MainTabReducer() }
+    // T3) 포어그라운드 복귀 트리거. TTL 게이트는 Repository 내부에서 흡수.
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         user.coordinator = coordinator
@@ -213,6 +217,12 @@ struct ContentView: View {
         .onChange(of: coordinator.rootView) { newValue in
             if newValue == .mainTab {
                 mainTabStore = Store(initialState: MainTabReducer.State()) { MainTabReducer() }
+            }
+        }
+        .onChange(of: scenePhase) { newPhase in
+            // .active 진입 시 펫 카탈로그 sync. 6h TTL 미만이면 Repository 가 캐시 반환으로 no-op.
+            if newPhase == .active {
+                Task { try? await PetCatalogRepository.liveValue.syncIfNeeded() }
             }
         }
     }

--- a/DDanDDan/Presenter/Components/PetImageView.swift
+++ b/DDanDDan/Presenter/Components/PetImageView.swift
@@ -34,8 +34,13 @@ struct PetImageView: View {
         }
         .frame(width: size?.width, height: size?.height)
         // type 또는 level 이 바뀌면 이전 task cancel + 새 task 시작.
+        // 시작 시 placeholder 로 리셋하고 await 후 취소 여부를 확인한 뒤에만 결과를 반영해서,
+        // 취소된 이전 task 의 stale 결과가 최신 상태를 덮어쓰지 않게 한다.
         .task(id: PetImageKey(type: type, level: level)) {
-            image = await repository.image(for: type, level: level)
+            image = nil
+            let loaded = await repository.image(for: type, level: level)
+            guard !Task.isCancelled else { return }
+            image = loaded
         }
     }
 

--- a/DDanDDan/Presenter/Components/PetImageView.swift
+++ b/DDanDDan/Presenter/Components/PetImageView.swift
@@ -1,0 +1,47 @@
+//
+//  PetImageView.swift
+//  DDanDDan
+//
+//  Created by mark.dd on 2026-05-13.
+//
+
+import SwiftUI
+import Dependencies
+
+/// `(PetType, Int)` 입력으로 `PetCatalogRepository` 로부터 비동기 이미지를 로드해 표시.
+/// 로드 전에는 번들 ImageResource 폴백 placeholder 로 즉시 그려 빈 프레임을 방지한다.
+struct PetImageView: View {
+    let type: PetType
+    let level: Int
+    /// nil 이면 부모 레이아웃에 맡긴다. 명시 값 전달 시 `.frame(width:height:)` 적용.
+    let size: CGSize?
+
+    @State private var image: UIImage?
+    @Dependency(\.petCatalogRepository) private var repository
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                // 초기 placeholder — 번들 ImageResource 즉시 표시.
+                Image(type.image(for: level))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+        }
+        .frame(width: size?.width, height: size?.height)
+        // type 또는 level 이 바뀌면 이전 task cancel + 새 task 시작.
+        .task(id: PetImageKey(type: type, level: level)) {
+            image = await repository.image(for: type, level: level)
+        }
+    }
+
+    /// `.task(id:)` 입력 키. 두 필드 중 하나라도 변하면 task 재실행 신호.
+    private struct PetImageKey: Hashable {
+        let type: PetType
+        let level: Int
+    }
+}

--- a/DDanDDan/Presenter/Home/Views/LevelUp/LevelUpView.swift
+++ b/DDanDDan/Presenter/Home/Views/LevelUp/LevelUpView.swift
@@ -64,10 +64,12 @@ struct LevelUpView: View {
     var imageView: some View {
         ZStack {
             Image(.pangGraphics)
-            Image(petType.image(for: level))
-                .resizable()
-                .frame(width: 96, height: 96)
-                .aspectRatio(contentMode: .fill)
+            // 카탈로그 기반 비동기 펫 이미지. size 명시로 frame 책임을 PetImageView 내부로 이동.
+            PetImageView(
+                type: petType,
+                level: level,
+                size: CGSize(width: 96, height: 96)
+            )
         }
     }
 }

--- a/DDanDDan/Presenter/Login/LoginViewModel.swift
+++ b/DDanDDan/Presenter/Login/LoginViewModel.swift
@@ -62,6 +62,8 @@ public class LoginViewModel: NSObject, ObservableObject {
             switch result {
             case .success(let loginData):
                 await UserManager.shared.login(loginData: loginData)
+                // T2) 로그인 직후 펫 카탈로그 force sync (fire-and-forget). 라우팅 차단 없음.
+                Task { try? await PetCatalogRepository.liveValue.syncIfNeeded(force: true) }
                 DispatchQueue.main.async { [weak self] in
                     self?.appCoordinator.triggerHomeUpdate(trigger: true)
                     if loginData.isOnboardingComplete {

--- a/DDanDDan/Repository/Dependencies/RepositoryDependency.swift
+++ b/DDanDDan/Repository/Dependencies/RepositoryDependency.swift
@@ -12,4 +12,9 @@ extension DependencyValues {
         get { self[FriendCardRepository.self] }
         set { self[FriendCardRepository.self] = newValue }
     }
+
+    var petCatalogRepository: PetCatalogRepository {
+        get { self[PetCatalogRepository.self] }
+        set { self[PetCatalogRepository.self] = newValue }
+    }
 }

--- a/DDanDDan/Repository/PetCatalogRepository.swift
+++ b/DDanDDan/Repository/PetCatalogRepository.swift
@@ -1,0 +1,197 @@
+//
+//  PetCatalogRepository.swift
+//  DDanDDan
+//
+//  Created by mark.dd on 2026-05-13.
+//
+
+import Foundation
+import UIKit
+import Dependencies
+
+/// 펫 카탈로그 단일 진실원(actor).
+/// - 메모리 + App Group UserDefaults 영속화
+/// - 6h TTL 게이트 + `currentSyncTask` dedup
+/// - 헤더 `X-Pet-Catalog-Version` 우선, 폴백 body version
+/// - 버전 변경 시 이미지 URL prefetch (백그라운드)
+public actor PetCatalogRepository {
+    // MARK: - State
+    private var cachedCatalog: PetCatalog?
+    private var lastSyncedAt: Date?
+    private var lastSeenVersion: String?
+    private var currentSyncTask: Task<PetCatalog, Error>?
+
+    // MARK: - Collaborators
+    private let network: PetCatalogNetwork
+    private let cache: PetAssetCache
+    private let appGroupID: String
+
+    // MARK: - Constants
+    /// App Group UserDefaults 키 — 버전 문자열.
+    private static let versionKey = "petCatalogVersion"
+    /// App Group UserDefaults 키 — 카탈로그 JSON 원본.
+    private static let catalogKey = "petCatalogJSON"
+    /// 6시간 TTL (force=false 경로에서만 적용).
+    private static let ttl: TimeInterval = 6 * 60 * 60
+
+    // MARK: - Init
+    public init(
+        network: PetCatalogNetwork,
+        cache: PetAssetCache,
+        appGroupID: String
+    ) {
+        self.network = network
+        self.cache = cache
+        self.appGroupID = appGroupID
+    }
+
+    // MARK: - Public API
+
+    /// 현재 보유한 카탈로그를 반환한다. 메모리 → App Group UserDefaults 복원 순서.
+    /// 네트워크 호출은 하지 않는다.
+    public func currentCatalog() -> PetCatalog? {
+        if let cachedCatalog {
+            return cachedCatalog
+        }
+        if let restored = restoreFromAppGroupUserDefaults() {
+            cachedCatalog = restored
+            return restored
+        }
+        return nil
+    }
+
+    /// 카탈로그 sync. TTL/dedup 게이트 통과 시 네트워크 호출.
+    /// - Parameter force: `true` 면 TTL 무시. 로그인 직후 등 강제 갱신용.
+    /// - Returns: 최신(또는 캐시된) `PetCatalog`.
+    /// - Throws: 네트워크 실패 시 `NetworkError` 전파.
+    @discardableResult
+    public func syncIfNeeded(force: Bool = false) async throws -> PetCatalog {
+        // 1) 진행 중 sync 가 있으면 결과 공유 (dedup)
+        if let task = currentSyncTask {
+            return try await task.value
+        }
+
+        // 2) TTL 게이트 — force=false 이고 6h 이내라면 캐시 반환
+        if !force,
+           let last = lastSyncedAt,
+           Date().timeIntervalSince(last) < Self.ttl,
+           let cached = currentCatalog() {
+            return cached
+        }
+
+        // 3) 신규 sync Task 등록 (self 직접 캡처: actor 격리됨)
+        let task = Task<PetCatalog, Error> {
+            let result = await network.fetchCatalog()
+            switch result {
+            case .failure(let error):
+                throw error
+            case .success(let payload):
+                let newVersion = payload.version ?? payload.catalog.version
+                let versionChanged = (newVersion != self.lastSeenVersion)
+                self.cachedCatalog = payload.catalog
+                self.lastSeenVersion = newVersion
+                self.lastSyncedAt = Date()
+                self.persistToAppGroupUserDefaults(
+                    catalog: payload.catalog,
+                    version: newVersion
+                )
+                if versionChanged {
+                    // prefetch 는 sync 반환 차단을 막기 위해 분리 Task 로 백그라운드 실행.
+                    let urls = self.collectImageURLs(from: payload.catalog)
+                    let cache = self.cache
+                    Task {
+                        await cache.prefetch(urls: urls)
+                    }
+                }
+                return payload.catalog
+            }
+        }
+        currentSyncTask = task
+        defer { currentSyncTask = nil }
+        return try await task.value
+    }
+
+    /// 타입/레벨에 대응하는 펫 이미지. 카탈로그 → cache.image → 번들 폴백.
+    public func image(for type: PetType, level: Int) async -> UIImage {
+        let safeLevel = max(1, min(level, 5))
+
+        // 1) 카탈로그 URL 조회 → 캐시 hit
+        if let catalog = currentCatalog(),
+           let item = catalog.pets.first(where: { $0.type == type.rawValue }),
+           let levelEntry = item.levels[String(safeLevel)],
+           let url = URL(string: levelEntry.imageUrl),
+           let image = await cache.image(for: url) {
+            return image
+        }
+
+        // 2) 번들 폴백 — 기존 PetType.image(for:)
+        let resource = type.image(for: safeLevel)
+        return UIImage(resource: resource)
+    }
+
+    // MARK: - Persistence Helpers
+
+    /// 카탈로그를 App Group UserDefaults 에 JSON 직렬화하여 저장.
+    /// 컨테이너 접근 실패 시 standard UserDefaults 폴백.
+    private func persistToAppGroupUserDefaults(catalog: PetCatalog, version: String) {
+        let defaults = appGroupDefaults()
+        do {
+            let data = try JSONEncoder().encode(catalog)
+            defaults.set(data, forKey: Self.catalogKey)
+            defaults.set(version, forKey: Self.versionKey)
+        } catch {
+            print("⚠️ PetCatalogRepository: persist 실패 - \(error.localizedDescription)")
+        }
+    }
+
+    /// App Group UserDefaults 에서 카탈로그 복원. 디코드 실패 시 nil.
+    private func restoreFromAppGroupUserDefaults() -> PetCatalog? {
+        let defaults = appGroupDefaults()
+        guard let data = defaults.data(forKey: Self.catalogKey) else {
+            return nil
+        }
+        do {
+            let catalog = try JSONDecoder().decode(PetCatalog.self, from: data)
+            if let version = defaults.string(forKey: Self.versionKey) {
+                lastSeenVersion = version
+            }
+            return catalog
+        } catch {
+            print("⚠️ PetCatalogRepository: restore 디코드 실패 - \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// 카탈로그 각 레벨의 imageUrl 을 URL 로 변환해 모아 반환. prefetch 대상.
+    private func collectImageURLs(from catalog: PetCatalog) -> [URL] {
+        var urls: [URL] = []
+        for pet in catalog.pets {
+            for (_, level) in pet.levels {
+                if let url = URL(string: level.imageUrl) {
+                    urls.append(url)
+                }
+            }
+        }
+        return urls
+    }
+
+    /// App Group UserDefaults 접근. 실패 시 standard 폴백 + 로그.
+    private func appGroupDefaults() -> UserDefaults {
+        if let defaults = UserDefaults(suiteName: appGroupID) {
+            return defaults
+        }
+        print("⚠️ PetCatalogRepository: App Group '\(appGroupID)' UserDefaults missing — fallback to standard")
+        return .standard
+    }
+}
+
+// MARK: - DependencyKey
+
+extension PetCatalogRepository: DependencyKey {
+    /// App, Widget, Watch 가 같은 actor 인스턴스를 공유하도록 단일 instance 유지.
+    public static let liveValue: PetCatalogRepository = PetCatalogRepository(
+        network: PetCatalogNetwork(),
+        cache: PetAssetCache.shared,
+        appGroupID: "group.com.DdanDdan"
+    )
+}

--- a/DDanDDan/Repository/PetCatalogRepository.swift
+++ b/DDanDDan/Repository/PetCatalogRepository.swift
@@ -31,6 +31,9 @@ public actor PetCatalogRepository {
     private static let versionKey = "petCatalogVersion"
     /// App Group UserDefaults 키 — 카탈로그 JSON 원본.
     private static let catalogKey = "petCatalogJSON"
+    /// App Group UserDefaults 키 — 마지막 동기화 시각(timeIntervalSinceReferenceDate, Double).
+    /// 앱 재시작 후에도 6시간 TTL 게이트가 유지되도록 영속화한다.
+    private static let lastSyncedAtKey = "petCatalogLastSyncedAt"
     /// 6시간 TTL (force=false 경로에서만 적용).
     private static let ttl: TimeInterval = 6 * 60 * 60
 
@@ -43,6 +46,15 @@ public actor PetCatalogRepository {
         self.network = network
         self.cache = cache
         self.appGroupID = appGroupID
+        // 영속화된 TTL 메타데이터 복원. 앱 재시작 직후 첫 sync 호출이 TTL 게이트를 적절히 통과/노옵하게 한다.
+        let defaults = UserDefaults(suiteName: appGroupID) ?? .standard
+        let storedTimestamp = defaults.double(forKey: Self.lastSyncedAtKey)
+        if storedTimestamp > 0 {
+            self.lastSyncedAt = Date(timeIntervalSinceReferenceDate: storedTimestamp)
+        }
+        if let version = defaults.string(forKey: Self.versionKey) {
+            self.lastSeenVersion = version
+        }
     }
 
     // MARK: - Public API
@@ -133,12 +145,16 @@ public actor PetCatalogRepository {
 
     /// 카탈로그를 App Group UserDefaults 에 JSON 직렬화하여 저장.
     /// 컨테이너 접근 실패 시 standard UserDefaults 폴백.
+    /// `lastSyncedAt` 도 함께 영속화하여 앱 재시작 후 TTL 게이트가 살아있도록 한다.
     private func persistToAppGroupUserDefaults(catalog: PetCatalog, version: String) {
         let defaults = appGroupDefaults()
         do {
             let data = try JSONEncoder().encode(catalog)
             defaults.set(data, forKey: Self.catalogKey)
             defaults.set(version, forKey: Self.versionKey)
+            if let lastSyncedAt {
+                defaults.set(lastSyncedAt.timeIntervalSinceReferenceDate, forKey: Self.lastSyncedAtKey)
+            }
         } catch {
             print("⚠️ PetCatalogRepository: persist 실패 - \(error.localizedDescription)")
         }

--- a/DDanDDan/Repository/PetCatalogRepository.swift
+++ b/DDanDDan/Repository/PetCatalogRepository.swift
@@ -59,17 +59,32 @@ public actor PetCatalogRepository {
 
     // MARK: - Public API
 
-    /// 현재 보유한 카탈로그를 반환한다. 메모리 → App Group UserDefaults 복원 순서.
-    /// 네트워크 호출은 하지 않는다.
+    /// 현재 보유한 카탈로그를 반환한다. 메모리 캐시를 반환하기 전에 App Group 의 저장된
+    /// 메타데이터(version/lastSyncedAt)와 비교하여, 다른 프로세스(메인 앱·Widget·Watch)가
+    /// 더 최신 카탈로그를 써둔 경우 stale 캐시를 갱신한다. 네트워크 호출은 하지 않는다.
     public func currentCatalog() -> PetCatalog? {
-        if let cachedCatalog {
-            return cachedCatalog
-        }
-        if let restored = restoreFromAppGroupUserDefaults() {
+        let defaults = appGroupDefaults()
+        let storedVersion = defaults.string(forKey: Self.versionKey)
+        let storedTimestamp = defaults.double(forKey: Self.lastSyncedAtKey)
+
+        let shouldReload: Bool = {
+            // 메모리 캐시 자체가 없으면 무조건 디스크에서 복원 시도.
+            guard cachedCatalog != nil else { return true }
+            // 디스크 버전 또는 sync 시각이 메모리보다 새것이면 갱신.
+            if let storedVersion, storedVersion != lastSeenVersion { return true }
+            if storedTimestamp > 0,
+               let memTimestamp = lastSyncedAt?.timeIntervalSinceReferenceDate,
+               storedTimestamp > memTimestamp { return true }
+            return false
+        }()
+
+        if shouldReload, let restored = restoreFromAppGroupUserDefaults() {
             cachedCatalog = restored
-            return restored
+            if storedTimestamp > 0 {
+                lastSyncedAt = Date(timeIntervalSinceReferenceDate: storedTimestamp)
+            }
         }
-        return nil
+        return cachedCatalog
     }
 
     /// 카탈로그 sync. TTL/dedup 게이트 통과 시 네트워크 호출.
@@ -124,11 +139,19 @@ public actor PetCatalogRepository {
     }
 
     /// 타입/레벨에 대응하는 펫 이미지. 카탈로그 → cache.image → 번들 폴백.
+    /// 카탈로그가 비어 있어도 sync가 진행 중이면 결과를 대기한 뒤 한 번 더 시도하여,
+    /// 콜드 스타트 시점에 첫 조회가 번들 이미지로 고착되는 것을 막는다.
     public func image(for type: PetType, level: Int) async -> UIImage {
         let safeLevel = max(1, min(level, 5))
 
+        // 카탈로그 확보: 메모리/디스크 → 진행 중 sync 결과 대기.
+        var catalog: PetCatalog? = currentCatalog()
+        if catalog == nil, let syncTask = currentSyncTask {
+            catalog = try? await syncTask.value
+        }
+
         // 1) 카탈로그 URL 조회 → 캐시 hit
-        if let catalog = currentCatalog(),
+        if let catalog,
            let item = catalog.pets.first(where: { $0.type == type.rawValue }),
            let levelEntry = item.levels[String(safeLevel)],
            let url = URL(string: levelEntry.imageUrl),


### PR DESCRIPTION
## 배경

PR #66 (Pet Catalog 인프라) 위에 단일 진실원 `PetCatalogRepository`와 sync 트리거 3종을 도입하고, HomeView 흐름의 첫 화면(LevelUpView)을 비동기 카탈로그 기반으로 전환한다.

> **base = `feature/pet-catalog-infrastructure` (스택 PR).** PR #66 머지 후 GitHub가 자동으로 base를 develop으로 변경한다.

> **HomeView 본문에는 정적 펫 이미지 패턴이 없다** — 모두 Lottie로 표시됨. 따라서 \"HomeView 흐름의 첫 정적 펫 화면\"인 LevelUpView가 본 PR의 단일 전환 대상.

## 변경 산출물

### 신규
- **`DDanDDan/Repository/PetCatalogRepository.swift`** — `actor`. 카탈로그 단일 진실원.
  - 메모리(`cachedCatalog`) + App Group UserDefaults(\`group.com.DdanDdan\`) 영속화
  - \`currentSyncTask\` dedup으로 동시 트리거(T1+T3 동시 발화 등) 중복 호출 차단
  - **6시간 TTL** 게이트 — \`force: false\` 호출은 6h 이내면 노옵
  - 헤더 \`X-Pet-Catalog-Version\` 우선 비교, body version 폴백
  - version 변경 시 \`PetAssetCache.shared.prefetch(urls:)\` 백그라운드 트리거(syncIfNeeded 반환 지연 없음)
  - \`image(for: PetType, level: Int) async -> UIImage\` — 카탈로그 → PetAssetCache → 번들 \`PetType.image(for:)\` 폴백 3단
  - \`DependencyKey\` + \`static let liveValue\` 단일 인스턴스
- **`DDanDDan/Presenter/Components/PetImageView.swift`** — SwiftUI 공용 래퍼.
  - \`.task(id: PetImageKey)\` 로 type/level 변경 감지 + 재로드
  - placeholder는 번들 \`Image(type.image(for: level))\` 으로 빈 프레임 회피
  - \`@Dependency(\\.petCatalogRepository)\` 사용

### 수정
- **`DDanDDan/Repository/Dependencies/RepositoryDependency.swift`** — \`petCatalogRepository\` computed property 등록
- **`DDanDDan/DDanDDanApp.swift`** —
  - **T1**: \`init()\` 안 KakaoSDK 초기화 직후 fire-and-forget \`syncIfNeeded()\` (콜드 스타트)
  - **T3**: \`ContentView\`에 \`@Environment(\\.scenePhase)\` + \`.onChange(of:)\` 추가, \`.active\` 진입 시 \`syncIfNeeded()\` (TTL은 Repository 내부에서 게이트)
- **`DDanDDan/Presenter/Login/LoginViewModel.swift`** —
  - **T2**: OAuth 성공 분기에서 \`UserManager.shared.login(loginData:)\` 직후 \`syncIfNeeded(force: true)\` (신규/계정전환 사용자가 즉시 최신 카탈로그 수신)
- **`DDanDDan/Presenter/Home/Views/LevelUp/LevelUpView.swift`** — \`Image(petType.image(for: level))\` → \`PetImageView(type:, level:, size: CGSize(96,96))\`
- **`DDanDDan.xcodeproj/project.pbxproj`** — 신규 2 파일을 DDanDDan 메인 타겟에 등록 (xcodeproj 1.27 gem 사용)

## 작업 내용

1. 단일 진실원 Repository 도입 — sync 트리거가 분산되어도 dedup으로 중복 네트워크 호출 방지.
2. 6h TTL로 포어그라운드 복귀 시 매번 호출되는 비용 회피.
3. 카탈로그 sync 실패 시 \`lastSyncedAt\` 미갱신 → TTL이 다음 호출을 막지 않음.
4. PetImageView는 placeholder(번들) 즉시 표시 후 async 로드 완료 시 SwiftUI 자연 재렌더.
5. HomeView 본문 전환은 본 PR 범위 외(Lottie 사용으로 정적 패턴 부재) — PR 3/4에서 PetArchive/Friends/Rank 일괄, Widget/Watch.

## 검증

- **빌드**: iPhone 17 Pro / iOS 26.3 sim, Debug — SUCCEEDED (65초). 에러 0건. 신규 경고 0건 (기존 경고는 pre-existing).
- **런타임 검증**: 본 PR은 (a) 앱 콜드 스타트가 카탈로그 fetch fire-and-forget을 트리거하고 (b) HomeView 진입까지 회귀 없음. LevelUpView 진입은 레벨업 발생 시점이라 시뮬레이터 보장 어려움 — 머지 후 dogfood로 확인 권장.
- **회귀**: HomeView, PetArchiveView, FriendsView, RankContentsView의 펫 표시 변경 없음 (PR 3에서 일괄 전환).

## 후속 인계

- **PR 3** — PetArchive / LevelUp 외 / Friends / Rank 일괄 전환
- **PR 4** — Widget / Watch 전환 + App Group 캐시 공유 검증
- **Lottie / backgrounds 전환** — 별도 마이그레이션
- **PetCatalogRepositoryTests** — 메인 앱 테스트 타겟 신설 후 추가

## 자체 리뷰 요약

ios-architect 계획(`_workspace_pr2/01_architect_plan.md`) 11단계 순서로 구현. R1~R8 위험 모두 완화 적용. 미해결 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 펫 이미지 카탈로그 추가: 비동기 로드 및 레벨별 번들 플레이스홀더 즉시 표시
  * 이미지 크기 지정 지원(프레임 적용)
  * 자동 동기화 트리거: 앱 시작, 앱 활성화, 로그인 직후(비차단 방식)
  * 백그라운드에서 카탈로그 변경 시 이미지 사전 캐싱 수행

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ddan-dda-ra/ddan-ddan-ios/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->