### PR TITLE
feat: PetArchive/Friends/Rank 정적 펫 이미지 → PetImageView 일괄 전환 (PR 3/4)

### DIFF
--- a/DDanDDan/Presenter/Friends/FriendsView.swift
+++ b/DDanDDan/Presenter/Friends/FriendsView.swift
@@ -128,10 +128,12 @@ struct FriendListView: View {
                 Circle()
                     .fill(friend.mainPetType.color)
                     .frame(width: 48, height: 48)
-                Image(friend.mainPetType.image(for: friend.petLevel))
-                    .resizable()
-                    .frame(width: 38, height: 38)
-                    .padding(3)
+                PetImageView(
+                    type: friend.mainPetType,
+                    level: friend.petLevel,
+                    size: CGSize(width: 38, height: 38)
+                )
+                .padding(3)
             }
             .padding(.trailing, 12)
             
@@ -172,10 +174,12 @@ struct FriendListView: View {
                     Circle()
                         .fill(store.myProfilePet.petType.color)
                         .frame(width: 48, height: 48)
-                    Image(store.myProfilePet.petType.image(for: store.myProfilePet.level))
-                        .resizable()
-                        .frame(width: 42, height: 42)
-                        .offset(y: -3)
+                    PetImageView(
+                        type: store.myProfilePet.petType,
+                        level: store.myProfilePet.level,
+                        size: CGSize(width: 42, height: 42)
+                    )
+                    .offset(y: -3)
                 }
                 .padding(.trailing, 12)
                 

--- a/DDanDDan/Presenter/Rank/RankContentsView.swift
+++ b/DDanDDan/Presenter/Rank/RankContentsView.swift
@@ -170,11 +170,13 @@ extension RankContentsView {
                 Circle()
                     .fill(rank.mainPetType.color)
                     .frame(width: 48, height: 48)
-                Image(rank.mainPetType.image(for: rank.petLevel))
-                    .resizable()
-                    .frame(width: 38, height: 38)
-                    .offset(y: rank.petLevel > 3 ? 0 : -3)
-                    .padding(3)
+                PetImageView(
+                    type: rank.mainPetType,
+                    level: rank.petLevel,
+                    size: CGSize(width: 38, height: 38)
+                )
+                .offset(y: rank.petLevel > 3 ? 0 : -3)
+                .padding(3)
             }
             .padding(.trailing, 12)
             
@@ -232,10 +234,12 @@ extension RankContentsView {
                         Circle()
                             .fill(myRanking?.mainPetType.color ?? .blueGraphics)
                             .frame(width: 48, height: 48)
-                        Image(myRanking?.mainPetType.image(for: myRanking?.petLevel ?? 0) ?? .blueEgg)
-                            .resizable()
-                            .frame(width: 42, height: 42)
-                            .offset(y: -3)
+                        PetImageView(
+                            type: myRanking?.mainPetType ?? .bluePenguin,
+                            level: myRanking?.petLevel ?? 1,
+                            size: CGSize(width: 42, height: 42)
+                        )
+                        .offset(y: -3)
                     }
                     .padding(.trailing, 12)
                     
@@ -293,10 +297,12 @@ struct RankCard: View {
     var body: some View {
         ZStack {
             VStack {
-                Image(ranking.mainPetType.image(for: ranking.petLevel))
-                    .resizable()
-                    .frame(width: 64, height: 64)
-                    .padding(.bottom, 10)
+                PetImageView(
+                    type: ranking.mainPetType,
+                    level: ranking.petLevel,
+                    size: CGSize(width: 64, height: 64)
+                )
+                .padding(.bottom, 10)
                 VStack {
                     Text(ranking.userName)
                         .font(.body2_regular14)

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -84,10 +84,11 @@ struct PetArchiveView: View {
                         
                     
                     if let pet = pet {
-                        Image(pet.type.image(for: pet.level))
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxWidth: 80, maxHeight: 80)
+                        PetImageView(
+                            type: pet.type,
+                            level: pet.level,
+                            size: CGSize(width: 80, height: 80)
+                        )
                     } else {
                         Image(.questionMark)
                             .resizable()


### PR DESCRIPTION
## 배경

PR #67 (PetCatalogRepository + LevelUpView)에 이어, 나머지 정적 펫 이미지 호출처 6곳을 \`PetImageView\` 로 일괄 전환한다.

> **base = `feature/pet-catalog-repository` (스택 PR).** PR #67 머지 후 GitHub가 자동 base 갱신.

## 변경 호출처

| 파일 | 라인 | 컨텍스트 | 사이즈 |
|------|------|---------|--------|
| \`PetArchiveView.swift\` | 87 | 보관함 3×3 그리드 | 80×80 |
| \`FriendsView.swift\` | 131 | 친구 목록 아이템 | 38×38 |
| \`FriendsView.swift\` | 175 | 내 프로필 | 42×42 |
| \`RankContentsView.swift\` | 173 | 랭킹 행 (level별 offset 유지) | 38×38 |
| \`RankContentsView.swift\` | 235 | 내 랭킹 (myRanking nil 시 bluePenguin lv1 폴백) | 42×42 |
| \`RankContentsView.swift\` | 296 | 랭킹 카드 | 64×64 |

## 변경 사항

- \`Image(petType.image(for: level))\` + 수동 \`.resizable()\` + \`.frame()\` 패턴 → \`PetImageView(type:, level:, size:)\` 단일 호출로 통일.
- 사이즈는 \`size: CGSize\` 인자로 PetImageView 내부에서 적용.
- 추가 modifier(\`.offset\`, \`.padding\`)는 외부에서 유지.
- 내 랭킹의 nil 처리: 기존 \`?? .blueEgg\` (`.bluePenguin` level 1 매핑)을 PR 2 PetImageView 시그니처에 맞춰 \`type ?? .bluePenguin, level ?? 1\` 로 변환 — 시각적 동일 결과.

## 검증

- **빌드**: iPhone 17 Pro / iOS 26.3 sim, Debug — SUCCEEDED (60초). 신규 에러 0건.
- **회귀 검증 권장 시나리오** (머지 후 dogfood):
  - 보관함 그리드 진입 → 모든 펫이 placeholder→async 로드 자연스럽게 표시
  - 친구 목록 / 내 프로필 → 펫 아이콘 정상
  - 랭킹(kcal/일) 탭 → 행/카드/내 랭킹 모두 정상
  - 첫 콜드 스타트(캐시 비움) + 비행기 모드 → 폴백 ImageResource로 표시

## 후속 인계

- **PR 4** — Widget / Watch 전환 + App Group 공유 캐시 검증.
- Lottie / backgrounds URL 전환 별도 마이그레이션.
- \`WatchSharedHomeModel.PetType.image(for:)\` "폴백 전용" 주석 추가 — PR 4와 함께 또는 별도.

## 자체 리뷰 요약

호출처 직접 grep 후 라인별 mechanical 교체. 시그니처 차이(\`size: CGSize?\` 와 기존 \`.frame()\`)는 PetImageView 내부로 흡수되어 외부 modifier 체인은 유지. 빌드 검증 SUCCEEDED.