### PR TITLE
feat: Widget + Watch에 App Group 캐시 reader 적용 (PR 4/4)

### DIFF
--- a/DDanDDan_Widget/DDanDDan_Widget.swift
+++ b/DDanDDan_Widget/DDanDDan_Widget.swift
@@ -7,6 +7,44 @@
 
 import WidgetKit
 import SwiftUI
+import CryptoKit
+
+/// App Group(`group.com.DdanDdan`) 의 카탈로그 JSON + 캐시 디렉토리에서 다운로드된 펫 이미지를 읽어온다.
+/// 없거나 실패 시 nil — 위젯은 번들 ImageResource 로 폴백.
+private func cachedWidgetPetImage(type: PetType, level: Int) -> UIImage? {
+    let groupID = "group.com.DdanDdan"
+    guard let userDefaults = UserDefaults(suiteName: groupID),
+          let json = userDefaults.data(forKey: "petCatalogJSON") else {
+        return nil
+    }
+
+    struct MinimalCatalog: Decodable {
+        struct Item: Decodable {
+            let type: String
+            let levels: [String: Level]
+        }
+        struct Level: Decodable {
+            let imageUrl: String
+        }
+        let pets: [Item]
+    }
+
+    guard let catalog = try? JSONDecoder().decode(MinimalCatalog.self, from: json),
+          let item = catalog.pets.first(where: { $0.type == type.rawValue }),
+          let urlString = item.levels[String(level)]?.imageUrl,
+          let url = URL(string: urlString),
+          let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupID) else {
+        return nil
+    }
+
+    let filename = SHA256.hash(data: Data(url.absoluteString.utf8))
+        .map { String(format: "%02x", $0) }
+        .joined()
+    let diskURL = container.appendingPathComponent("pet-assets").appendingPathComponent(filename)
+    guard let data = try? Data(contentsOf: diskURL) else { return nil }
+    return UIImage(data: data)
+}
+
 struct ActivityEntry: TimelineEntry {
     let date: Date
     let activeEnergy: Int
@@ -79,7 +117,7 @@ struct DDanDDan_WidgetEntryView : View {
                     kcalView
                     Spacer()
                 }
-                Image(PetType(rawValue:activityEntry.petType)?.image(for: activityEntry.petLevel) ?? .blueEgg)
+                petImage(for: activityEntry)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 64, height: 64)
@@ -96,6 +134,15 @@ struct DDanDDan_WidgetEntryView : View {
 
     }
     
+    private func petImage(for entry: ActivityEntry) -> Image {
+        let petType = PetType(rawValue: entry.petType)
+        if let type = petType,
+           let cached = cachedWidgetPetImage(type: type, level: entry.petLevel) {
+            return Image(uiImage: cached)
+        }
+        return Image(petType?.image(for: entry.petLevel) ?? .blueEgg)
+    }
+
     var kcalView: some View {
         ZStack {
             HStack(alignment: .firstTextBaseline, spacing: 2) {

--- a/DdanDdan_Watch Watch App/View/ContentView.swift
+++ b/DdanDdan_Watch Watch App/View/ContentView.swift
@@ -38,10 +38,18 @@ struct ContentView: View {
     }
     
     var imageView: some View {
-        Image(viewModel.viewConfig?.0 ?? .blueEgg)
-            .resizable()
-            .scaledToFit()
-            .frame(width: 100, height: 100) 
+        Group {
+            if let cached = viewModel.cachedPetImage {
+                Image(uiImage: cached)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(viewModel.viewConfig?.0 ?? .blueEgg)
+                    .resizable()
+                    .scaledToFit()
+            }
+        }
+        .frame(width: 100, height: 100)
     }
     
     var body: some View {

--- a/DdanDdan_Watch Watch App/View/WatchViewModel.swift
+++ b/DdanDdan_Watch Watch App/View/WatchViewModel.swift
@@ -7,14 +7,18 @@
 
 import SwiftUI
 import Combine
+import CryptoKit
 
 final class WatchViewModel: ObservableObject {
     var cancellables = Set<AnyCancellable>()
-    
+
     @Published var goalKcal: Int?
     @Published var currentKcal: Int
     @Published var currentKcalProgress: Double = 0.0
     @Published var viewConfig: (ImageResource, Color)?
+    /// App Group 캐시에서 로드된 펫 이미지. 메인 앱이 카탈로그를 sync해두면 여기로 들어오고,
+    /// 없으면 nil → 뷰는 viewConfig 의 번들 ImageResource 폴백 사용.
+    @Published var cachedPetImage: UIImage?
     @Published var showLoginAlert = false
     
     private let healthKitManager: HealthKitManager = .shared
@@ -52,6 +56,42 @@ final class WatchViewModel: ObservableObject {
     public func configureUI(petType: PetType, level: Int) -> (ImageResource, Color) {
         return (petType.image(for: level), petType.color)
     }
+
+    /// App Group(`group.com.DdanDdan`) 의 카탈로그 JSON + 캐시 디렉토리에서
+    /// 다운로드된 펫 이미지를 읽어온다. 없거나 실패 시 nil — 뷰는 번들 ImageResource 로 폴백.
+    static func cachedPetImage(type: PetType, level: Int) -> UIImage? {
+        let groupID = "group.com.DdanDdan"
+        guard let userDefaults = UserDefaults(suiteName: groupID),
+              let json = userDefaults.data(forKey: "petCatalogJSON") else {
+            return nil
+        }
+
+        struct MinimalCatalog: Decodable {
+            struct Item: Decodable {
+                let type: String
+                let levels: [String: Level]
+            }
+            struct Level: Decodable {
+                let imageUrl: String
+            }
+            let pets: [Item]
+        }
+
+        guard let catalog = try? JSONDecoder().decode(MinimalCatalog.self, from: json),
+              let item = catalog.pets.first(where: { $0.type == type.rawValue }),
+              let urlString = item.levels[String(level)]?.imageUrl,
+              let url = URL(string: urlString),
+              let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupID) else {
+            return nil
+        }
+
+        let filename = SHA256.hash(data: Data(url.absoluteString.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let diskURL = container.appendingPathComponent("pet-assets").appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: diskURL) else { return nil }
+        return UIImage(data: data)
+    }
     
     /// 도달률 계산
     private func calculateProgress() -> Double {
@@ -71,11 +111,15 @@ final class WatchViewModel: ObservableObject {
         .receive(on: DispatchQueue.main)
         .sink { [weak self] purposeKcal, petType, level in
             guard let self = self else { return }
-            
+
             // 데이터 통합 처리
             self.goalKcal = Int(purposeKcal)
             if let petTypeEnum = PetType(rawValue: petType) {
                 self.viewConfig = self.configureUI(petType: petTypeEnum, level: level)
+                // App Group 캐시에서 다운로드된 이미지를 읽어 우선 사용. 없으면 viewConfig 의 번들 폴백.
+                self.cachedPetImage = Self.cachedPetImage(type: petTypeEnum, level: level)
+            } else {
+                self.cachedPetImage = nil
             }
             self.updateProgress()
         }


### PR DESCRIPTION
## 배경

PR #67/#68의 메인 앱 카탈로그 sync로 App Group 컨테이너(`group.com.DdanDdan/pet-assets/`)에 펫 이미지가 캐시된다. 본 PR은 Widget extension과 Watch app이 이 캐시를 읽도록 한다.

> **base = `feature/pet-catalog-screens` (스택 PR).** PR #67 → #68 → #69 (본 PR) 순차 머지 후 GitHub가 자동 base 갱신.

## 설계 결정 — 인라인 reader 패턴

`PetCatalogRepository` 전체를 Widget/Watch 타겟에 cross-target 멤버십으로 추가하면 \`Dependencies\`/\`Alamofire\` 의존성까지 끌어와야 한다. 본 PR은 단순화 위해 각 타겟에 **읽기 전용 인라인 reader**를 둔다:

- **Widget** — `cachedWidgetPetImage(type:level:)` 파일 스코프 함수 (`DDanDDan_Widget.swift`)
- **Watch** — `WatchViewModel.cachedPetImage(type:level:)` 정적 메서드

두 reader는:
- App Group \`UserDefaults\` 의 \`petCatalogJSON\` 을 미니멀 inline \`Decodable\` 구조체로 디코드 (PetCatalog 모델 cross-target 멤버십 불필요)
- 펫 type/level → imageUrl 룩업
- SHA256 hex 파일명 (메인 앱 \`PetAssetCache\` 와 동일 알고리즘)
- App Group 컨테이너 \`pet-assets/{sha256}\` 에서 Data 로드 → UIImage
- 어느 단계든 실패 시 nil → 기존 번들 ImageResource 폴백 그대로

## 변경 산출물

### Widget (`DDanDDan_Widget/DDanDDan_Widget.swift`)
- \`import CryptoKit\`
- 파일 스코프 \`cachedWidgetPetImage(type:level:) -> UIImage?\`
- \`DDanDDan_WidgetEntryView\`에 \`petImage(for:) -> Image\` private 헬퍼 추가 — 캐시 hit 시 \`Image(uiImage:)\`, miss 시 기존 \`Image(petType?.image(for:) ?? .blueEgg)\`

### Watch (`DdanDdan_Watch Watch App/`)
- \`WatchViewModel.swift\`:
  - \`import CryptoKit\` 추가
  - \`@Published var cachedPetImage: UIImage?\` 신규
  - \`static func cachedPetImage(type:level:) -> UIImage?\` 신규
  - \`bindWatchApp\` 의 CombineLatest3 sink에서 petType/level 갱신 시 \`Self.cachedPetImage(...)\` 호출하여 갱신
- \`ContentView.swift\`:
  - \`imageView\` 가 \`viewModel.cachedPetImage\` 우선, nil 일 때 기존 \`viewConfig?.0 ?? .blueEgg\` 폴백

## 검증

- **Widget Extension**: iPhone 17 Pro / iOS 26.3 sim, Debug — SUCCEEDED (60초)
- **Watch App**: Apple Watch Series 11 (46mm) / watchOS 26.2 sim, Debug — SUCCEEDED (62초)
- 신규 에러 0건. LSP 진단은 인덱싱 노이즈로 확인.

## 회귀 위험

- **첫 콜드 스타트 + 메인 앱 미실행**: App Group UserDefaults에 \`petCatalogJSON\` 없음 → reader 즉시 nil → 번들 폴백 → 기존 동작 동일.
- **메인 앱이 sync 완료 후 Widget timeline refresh**: 캐시 파일 존재 시 \`Image(uiImage:)\` 로 표시.
- **TokenInterceptor 의존성**: Widget/Watch는 네트워크 호출 없음 — TokenInterceptor 무관. 메인 앱이 prime 한 디스크 캐시만 읽음.

## 후속 인계 (전체 마이그레이션 종료)

본 PR로 PR 1~4 시리즈 완료:
- PR #66 — 인프라 (PetCatalog/PetCatalogNetwork/PetAssetCache + App Group)
- PR #67 — Repository + sync 트리거 + LevelUpView 전환
- PR #68 — PetArchive/Friends/Rank 일괄 전환
- PR #69 (본 PR) — Widget/Watch 캐시 reader

후속 별도 마이그레이션:
- Lottie 애니메이션 (\`lottieDefaultUrl\`, \`lottiePlayEatUrl\`) URL 전환
- backgrounds 3종 URL 전환
- SVGKit SPM 도입 + \`PetAssetCache.decode()\` SVG 디코드 활성화
- NetworkManager 헤더 노출 API 통합 (PetCatalogNetwork 중복 정리)
- TokenInterceptor 일원화 (수동 Authorization 헤더 주입 제거)
- 메인 앱 테스트 타겟 신설