### PR TITLE
fix: 펫 뽑기 따닥 방지 (in-flight 가드 + 버튼 disabled)

### DIFF
--- a/DDanDDan/Presenter/Home/RandomGachaPetView.swift
+++ b/DDanDDan/Presenter/Home/RandomGachaPetView.swift
@@ -68,12 +68,14 @@ struct RandomGachaPetView: View {
                                     viewModel.tapGrowupButton()
                                 }
                                 .buttonStyle(PrimaryButtonStyle())
+                                .disabled(viewModel.isGrowupInProgress)
                             } else {
                                 Button("선택하기") {
                                     AnalyticsManager.shared.logEvent(event: HomeEvent.clickBtn())
                                     viewModel.tapSelectButton()
                                 }
                                 .buttonStyle(PrimaryButtonStyle())
+                                .disabled(viewModel.isGachaInProgress)
                             }
                         }
                     }

--- a/DDanDDan/Presenter/Home/RandomGachaPetViewModel.swift
+++ b/DDanDDan/Presenter/Home/RandomGachaPetViewModel.swift
@@ -21,10 +21,13 @@ final class RandomGachaPetViewModel: ObservableObject {
     /// 메인 펫 설정 API 진행 중 플래그.
     @Published var isGrowupInProgress: Bool = false
 
+    /// 가챠 의존성을 주입해 초기화한다.
     init(homeRepository: HomeRepositoryProtocol) {
         self.homeRepository = homeRepository
     }
 
+    /// "선택하기" 버튼 핸들러. 랜덤 펫 가챠를 실행한다.
+    /// 진행 중(`isGachaInProgress`)이면 따닥(중복 호출)을 무시한다.
     func tapSelectButton() {
         guard !isGachaInProgress else { return }
         isGachaInProgress = true
@@ -42,6 +45,8 @@ final class RandomGachaPetViewModel: ObservableObject {
     }
 
 
+    /// "키우기" 버튼 핸들러. 뽑은 펫을 메인 펫으로 설정한다.
+    /// 진행 중(`isGrowupInProgress`)이면 따닥(중복 호출)을 무시한다.
     func tapGrowupButton() {
         guard !isGrowupInProgress else { return }
         guard let gachaResultId = gachaResult?.id else {
@@ -57,11 +62,13 @@ final class RandomGachaPetViewModel: ObservableObject {
         }
     }
     
+    /// "닫기" 버튼 핸들러. 가챠 화면을 닫는다.
     func tapDisMissButton() {
         dismissPublisher.send()
         isSelectedRandomPet = false
     }
-    
+
+    /// 가챠 API를 호출해 새 랜덤 펫을 받아 `gachaResult`에 보관한다.
     private func selectRandomPet() async {
         let randomPetResult = await homeRepository.addNewGachaRandomPet()
         switch randomPetResult {
@@ -75,6 +82,7 @@ final class RandomGachaPetViewModel: ObservableObject {
     }
 
     
+    /// 주어진 펫 ID를 메인 펫으로 설정하는 API를 호출한다.
     private func setRandomPetToMainPet(_ petId: String) async {
         let setMainPetResult = await homeRepository.updateMainPet(petId: petId)
         switch setMainPetResult {

--- a/DDanDDan/Presenter/Home/RandomGachaPetViewModel.swift
+++ b/DDanDDan/Presenter/Home/RandomGachaPetViewModel.swift
@@ -16,33 +16,43 @@ final class RandomGachaPetViewModel: ObservableObject {
     
     @Published var gachaResult: Pet?
     @Published var isSelectedRandomPet: Bool = false
-    
+    /// 가챠 API 진행 중 플래그. 따닥 방지(in-flight guard) 및 버튼 비활성화 바인딩에 사용.
+    @Published var isGachaInProgress: Bool = false
+    /// 메인 펫 설정 API 진행 중 플래그.
+    @Published var isGrowupInProgress: Bool = false
+
     init(homeRepository: HomeRepositoryProtocol) {
         self.homeRepository = homeRepository
     }
-    
+
     func tapSelectButton() {
+        guard !isGachaInProgress else { return }
+        isGachaInProgress = true
         gachaResult = nil
-        
+
         Task {
             await selectRandomPet()
             await MainActor.run {
                 if gachaResult != nil {
                     isSelectedRandomPet = true
                 }
+                isGachaInProgress = false
             }
         }
     }
 
-    
+
     func tapGrowupButton() {
+        guard !isGrowupInProgress else { return }
         guard let gachaResultId = gachaResult?.id else {
             return
         }
-        
+        isGrowupInProgress = true
+
         Task { @MainActor in
             await setRandomPetToMainPet(gachaResultId)
             isSelectedRandomPet = false
+            isGrowupInProgress = false
             dismissPublisher.send()
         }
     }


### PR DESCRIPTION
## Summary
- 펫 뽑기 화면에서 "선택하기"/"키우기" 버튼 따닥(빠른 연속 탭) 시 API가 N번 호출되어 알·메인펫이 N개 생성되는 문제 수정
- ViewModel에 `isGachaInProgress` / `isGrowupInProgress` `@Published` 플래그 도입, guard로 중복 호출 차단
- View의 두 버튼에 `.disabled(isXxxInProgress)` 바인딩 — 사용자에게 비활성 피드백 제공

## 원인
`RandomGachaPetViewModel.tapSelectButton` / `tapGrowupButton`은 매 호출마다 `Task`를 spawn했고, 진행 중 가드가 없어 따닥 시 동일 API(`POST /v1/pets/me/gacha`, `PUT /v1/users/me/main-pet`)가 동시에 N번 발사됨.

## 변경 사항
- `DDanDDan/Presenter/Home/RandomGachaPetViewModel.swift`
  - `isGachaInProgress`, `isGrowupInProgress` 플래그 추가
  - `tapSelectButton`/`tapGrowupButton`에 in-flight guard
  - Task 완료 시(success/failure 모두) 플래그 false 복원
- `DDanDDan/Presenter/Home/RandomGachaPetView.swift`
  - "선택하기": `.disabled(viewModel.isGachaInProgress)`
  - "키우기": `.disabled(viewModel.isGrowupInProgress)`

## Test plan
- [ ] 펫 뽑기 모달에서 "선택하기" 빠른 연속 탭 → 알 한 번만 생성됨
- [ ] "키우기" 빠른 연속 탭 → main-pet 설정 1회만 호출
- [ ] API 진행 중 버튼 비활성화(흐림) 상태 시각 확인
- [ ] 정상 완료 후 모달 dismiss 동작 회귀 없음
- [ ] 가챠 API 실패 시 버튼 다시 활성화되어 재시도 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Bug Fixes**
  * 가챠 선택 및 성장 기능 진행 중 버튼 상호작용 제한 기능을 추가하여 중복 작동을 방지했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ddan-dda-ra/ddan-ddan-ios/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->