### PR TITLE
fix: 펫 변경 후 홈 stale 깜빡임 제거

### DIFF
--- a/DDanDDan/AppCoordinator.swift
+++ b/DDanDDan/AppCoordinator.swift
@@ -21,6 +21,7 @@ enum AppPath: Hashable {
 struct PetChangePayload: Equatable {
     let petType: PetType
     let level: Int
+    let expPercent: Double
 }
 
 final class AppCoordinator: ObservableObject {
@@ -45,9 +46,9 @@ final class AppCoordinator: ObservableObject {
     /// fetchHomeInfo() 비동기 완료를 기다리지 않고 배경/펫이 바로 새것으로 표시되도록 한다.
     @Published private(set) var pendingPetChange: PetChangePayload?
 
-    func triggerPetChanged(petType: PetType? = nil, level: Int? = nil) {
-        if let petType, let level {
-            pendingPetChange = PetChangePayload(petType: petType, level: level)
+    func triggerPetChanged(petType: PetType? = nil, level: Int? = nil, expPercent: Double? = nil) {
+        if let petType, let level, let expPercent {
+            pendingPetChange = PetChangePayload(petType: petType, level: level, expPercent: expPercent)
         }
         petChangedSession = UUID()
     }

--- a/DDanDDan/AppCoordinator.swift
+++ b/DDanDDan/AppCoordinator.swift
@@ -17,6 +17,12 @@ enum AppPath: Hashable {
     case login
 }
 
+/// 메인 펫 변경 시 홈에 즉시 반영할 새 펫 정보.
+struct PetChangePayload: Equatable {
+    let petType: PetType
+    let level: Int
+}
+
 final class AppCoordinator: ObservableObject {
     // 루트뷰
     @Published var rootView: AppPath = .splash
@@ -35,7 +41,14 @@ final class AppCoordinator: ObservableObject {
     @Published private(set) var shouldUpdateHomeView = false
     @Published private(set) var petChangedSession: UUID = UUID()
 
-    func triggerPetChanged() {
+    /// 메인 펫 변경 시, 새 펫 정보(petType/level)를 홈에 즉시 동기 반영하기 위한 페이로드.
+    /// fetchHomeInfo() 비동기 완료를 기다리지 않고 배경/펫이 바로 새것으로 표시되도록 한다.
+    @Published private(set) var pendingPetChange: PetChangePayload?
+
+    func triggerPetChanged(petType: PetType? = nil, level: Int? = nil) {
+        if let petType, let level {
+            pendingPetChange = PetChangePayload(petType: petType, level: level)
+        }
         petChangedSession = UUID()
     }
 

--- a/DDanDDan/AppCoordinator.swift
+++ b/DDanDDan/AppCoordinator.swift
@@ -46,11 +46,19 @@ final class AppCoordinator: ObservableObject {
     /// fetchHomeInfo() 비동기 완료를 기다리지 않고 배경/펫이 바로 새것으로 표시되도록 한다.
     @Published private(set) var pendingPetChange: PetChangePayload?
 
-    func triggerPetChanged(petType: PetType? = nil, level: Int? = nil, expPercent: Double? = nil) {
-        if let petType, let level, let expPercent {
-            pendingPetChange = PetChangePayload(petType: petType, level: level, expPercent: expPercent)
+    @MainActor
+    func triggerPetChanged(payload: PetChangePayload? = nil) {
+        if let payload {
+            pendingPetChange = payload
         }
         petChangedSession = UUID()
+    }
+
+    /// 페이로드를 1회 소비한다. 새 sink가 attach될 때 latched된 옛 payload가
+    /// 다시 발화되어 stale로 회귀하는 것을 막기 위함.
+    @MainActor
+    func consumePendingPetChange() {
+        pendingPetChange = nil
     }
 
     func setRoot(to path: AppPath) {

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -152,7 +152,7 @@ struct HomeView: View {
         }
         .onReceive(coordinator.$pendingPetChange.compactMap { $0 }) { change in
             // 펫 변경 즉시 배경/펫을 새것으로 동기 반영 (stale 깜빡임 방지)
-            viewModel.applyPetChange(petType: change.petType, level: change.level)
+            viewModel.applyPetChange(petType: change.petType, level: change.level, expPercent: change.expPercent)
         }
         .onReceive(coordinator.$shouldUpdateHomeView) { shouldUpdate in
             if shouldUpdate {

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -150,6 +150,10 @@ struct HomeView: View {
                 viewModel.isGoalMet = false
             }
         }
+        .onReceive(coordinator.$pendingPetChange.compactMap { $0 }) { change in
+            // 펫 변경 즉시 배경/펫을 새것으로 동기 반영 (stale 깜빡임 방지)
+            viewModel.applyPetChange(petType: change.petType, level: change.level)
+        }
         .onReceive(coordinator.$shouldUpdateHomeView) { shouldUpdate in
             if shouldUpdate {
                 Task {

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -153,6 +153,7 @@ struct HomeView: View {
         .onReceive(coordinator.$pendingPetChange.compactMap { $0 }) { change in
             // 펫 변경 즉시 배경/펫을 새것으로 동기 반영 (stale 깜빡임 방지)
             viewModel.applyPetChange(petType: change.petType, level: change.level, expPercent: change.expPercent)
+            coordinator.consumePendingPetChange()
         }
         .onReceive(coordinator.$shouldUpdateHomeView) { shouldUpdate in
             if shouldUpdate {

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -132,6 +132,18 @@ final class HomeViewModel: ObservableObject {
         generator.prepare()
     }
     
+    /// 메인 펫 변경 시 새 petType/level을 홈 상태에 즉시 동기 반영한다.
+    /// fetchHomeInfo() 완료를 기다리지 않으므로 이전 펫이 잠깐 보이는 stale 깜빡임을 막는다.
+    /// 칼로리/경험치 등 나머지 정보는 이어지는 fetchHomeInfo()가 갱신한다.
+    @MainActor
+    func applyPetChange(petType: PetType, level: Int) {
+        homePetModel.petType = petType
+        homePetModel.level = level
+        // 변경 직후 이전 펫 애니메이션이 남지 않도록 특수 애니메이션 상태를 초기화한다.
+        isPlayingSpecialAnimation = false
+        currentLottieAnimation = ""
+    }
+
     @MainActor
     func fetchHomeInfo() async {
         

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -136,9 +136,10 @@ final class HomeViewModel: ObservableObject {
     /// fetchHomeInfo() 완료를 기다리지 않으므로 이전 펫이 잠깐 보이는 stale 깜빡임을 막는다.
     /// 칼로리/경험치 등 나머지 정보는 이어지는 fetchHomeInfo()가 갱신한다.
     @MainActor
-    func applyPetChange(petType: PetType, level: Int) {
+    func applyPetChange(petType: PetType, level: Int, expPercent: Double) {
         homePetModel.petType = petType
         homePetModel.level = level
+        homePetModel.exp = expPercent
         // 변경 직후 이전 펫 애니메이션이 남지 않도록 특수 애니메이션 상태를 초기화한다.
         isPlayingSpecialAnimation = false
         currentLottieAnimation = ""

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -132,9 +132,13 @@ final class HomeViewModel: ObservableObject {
         generator.prepare()
     }
     
-    /// 메인 펫 변경 시 새 petType/level을 홈 상태에 즉시 동기 반영한다.
+    /// 메인 펫 변경 시 새 petType/level/exp를 홈 상태에 즉시 동기 반영한다.
     /// fetchHomeInfo() 완료를 기다리지 않으므로 이전 펫이 잠깐 보이는 stale 깜빡임을 막는다.
-    /// 칼로리/경험치 등 나머지 정보는 이어지는 fetchHomeInfo()가 갱신한다.
+    ///
+    /// 펫 시각화에 필요한 petType/level/exp만 즉시 반영하며,
+    /// feedCount/toyCount/ticket/goalKcal/currentKcal 등 나머지 정보는
+    /// 이어 호출되는 fetchHomeInfo()가 일괄 덮어쓴다. 이 사이의 짧은 윈도우에서
+    /// 위 카운트 필드들이 이전 값일 수 있다.
     @MainActor
     func applyPetChange(petType: PetType, level: Int, expPercent: Double) {
         homePetModel.petType = petType

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -65,11 +65,10 @@ struct PetArchiveView: View {
             if newValue {
                 coordinator.triggerHomeUpdate(trigger: true)
                 // 새 펫 정보를 함께 실어 홈 배경/펫이 즉시 갱신되도록 한다 (stale 깜빡임 방지)
-                coordinator.triggerPetChanged(
-                    petType: viewModel.selectedMainPet?.type,
-                    level: viewModel.selectedMainPet?.level,
-                    expPercent: viewModel.selectedMainPet?.expPercent
-                )
+                let payload = viewModel.selectedMainPet.map {
+                    PetChangePayload(petType: $0.type, level: $0.level, expPercent: $0.expPercent)
+                }
+                coordinator.triggerPetChanged(payload: payload)
                 coordinator.pop()
             }
         }

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -64,7 +64,11 @@ struct PetArchiveView: View {
         .onChange(of: viewModel.isSelectedMainPet) { newValue in
             if newValue {
                 coordinator.triggerHomeUpdate(trigger: true)
-                coordinator.triggerPetChanged()
+                // 새 펫 정보를 함께 실어 홈 배경/펫이 즉시 갱신되도록 한다 (stale 깜빡임 방지)
+                coordinator.triggerPetChanged(
+                    petType: viewModel.selectedMainPet?.type,
+                    level: viewModel.selectedMainPet?.level
+                )
                 coordinator.pop()
             }
         }

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -67,7 +67,8 @@ struct PetArchiveView: View {
                 // 새 펫 정보를 함께 실어 홈 배경/펫이 즉시 갱신되도록 한다 (stale 깜빡임 방지)
                 coordinator.triggerPetChanged(
                     petType: viewModel.selectedMainPet?.type,
-                    level: viewModel.selectedMainPet?.level
+                    level: viewModel.selectedMainPet?.level,
+                    expPercent: viewModel.selectedMainPet?.expPercent
                 )
                 coordinator.pop()
             }

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
@@ -17,7 +17,7 @@ final class PetArchiveViewModel: ObservableObject {
     @Published var petId: String = ""
     @Published var isSelectedMainPet: Bool = false
     /// 변경된 메인 펫 정보 — 홈에 petType/level을 즉시 동기 반영하기 위해 보관.
-    @Published var selectedMainPet: Pet? = nil
+    @Published private(set) var selectedMainPet: Pet? = nil
     @Published var showToast = false
     @Published var gridItemCount: Int = 9
     @Published var toastMessage: String = "새로운 펫을 준비 중이에요!"
@@ -106,7 +106,7 @@ final class PetArchiveViewModel: ObservableObject {
         if case .success(let pet) = result {
             UserDefaultValue.petId = pet.mainPet.id
             UserDefaultValue.petType = pet.mainPet.type.rawValue
-            DispatchQueue.main.async { [weak self] in
+            await MainActor.run { [weak self] in
                 self?.selectedMainPet = pet.mainPet
                 self?.isSelectedMainPet = true
             }

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
@@ -16,6 +16,8 @@ final class PetArchiveViewModel: ObservableObject {
     @Published var selectedIndex: Int? = nil
     @Published var petId: String = ""
     @Published var isSelectedMainPet: Bool = false
+    /// 변경된 메인 펫 정보 — 홈에 petType/level을 즉시 동기 반영하기 위해 보관.
+    @Published var selectedMainPet: Pet? = nil
     @Published var showToast = false
     @Published var gridItemCount: Int = 9
     @Published var toastMessage: String = "새로운 펫을 준비 중이에요!"
@@ -105,6 +107,7 @@ final class PetArchiveViewModel: ObservableObject {
             UserDefaultValue.petId = pet.mainPet.id
             UserDefaultValue.petType = pet.mainPet.type.rawValue
             DispatchQueue.main.async { [weak self] in
+                self?.selectedMainPet = pet.mainPet
                 self?.isSelectedMainPet = true
             }
         }


### PR DESCRIPTION
## Summary
펫 보관함에서 메인 펫 변경 후 홈 진입 시, **이전 펫 배경/펫이 잠깐 보였다가** 새 펫으로 바뀌는 깜빡임(~100-300ms)을 제거합니다.

## 원인
`HomeViewModel.homePetModel`(@Published)이 이전 펫 값을 유지하다가, 홈 진입 후 `fetchHomeInfo()` 비동기 완료 시점에야 갱신됨. 그 사이 `petBackgroundView`가 이전 petType으로 즉시 렌더 → stale 깜빡임.

## 수정 (방향 1: 즉시 동기 업데이트)
펫 변경 시 새 petType을 홈 상태에 **즉시 반영**하여 fetchHomeInfo 완료를 기다리지 않게 함.

- **AppCoordinator**: `PetChangePayload`(petType, level) struct + `pendingPetChange` 채널 추가 (기존 `petChangedSession` UUID는 유지 → MainTabView 호환, 회귀 방지)
- **PetArchiveViewModel**: `selectedMainPet` 보관, 변경 성공 시 payload 전달
- **HomeViewModel**: `applyPetChange(petType:level:)` — petType/level 즉시 갱신 + 애니메이션 상태 초기화
- **HomeView**: `pendingPetChange` 수신 시 즉시 `applyPetChange` 호출 (기존 `shouldUpdateHomeView` 핸들러는 나머지 정보 갱신용으로 유지)

WatchSharedHomeModel/PetType은 건드리지 않았고, 로딩 스피너 등은 추가하지 않음(방향 1 최소 변경).

## 라운드 2 — 셀프 리뷰 반영 (CodeRabbit rate limit 대체)
CodeRabbit이 organization 크레딧 소진으로 정상 리뷰 불가. swift-reviewer로 셀프 리뷰 후 차단성 2건 + 합리적 4건을 반영했습니다.

- **Blocker**: `pendingPetChange` latched 회귀 — `AppCoordinator.consumePendingPetChange()` 도입, HomeView 핸들러에서 1회 소비
- **Blocker**: `triggerPetChanged` 옵셔널 사일런트 노옵 — `PetChangePayload` single-payload API로 강제
- `HomeViewModel.applyPetChange` docstring 보강 (즉시 반영 필드 vs fetchHomeInfo 후속 갱신 필드 구분)
- `AppCoordinator.triggerPetChanged`에 `@MainActor` 명시
- `PetArchiveViewModel.selectedMainPet` `private(set)` 캡슐화
- `PetArchiveViewModel.selectMainPet`의 main hop `DispatchQueue.main.async` → `await MainActor.run` 컨벤션 일관성

## Follow-up (별도 PR)
- 가챠 경로(`RandomGachaPetViewModel.tapGrowupButton`)에서도 동일 stale 깜빡임 발생 가능 — 같은 방식으로 즉시 동기 반영 적용 필요
- watchOS 즉시 동기화 — 현재는 `fetchHomeInfo()` 응답까지 워치가 stale 펫을 잠시 표시할 수 있음. `transferUserInfo`로 즉시 전송 검토

## Test plan
- [x] iPhone 17 Pro 빌드 성공 (라운드 2 후 재검증 ✓)
- [ ] 펫 보관함에서 펫 변경 → 홈 진입 시 깜빡임 없이 즉시 새 펫 표시
- [ ] 변경 후 칼로리/경험치 등 나머지 정보도 정상 갱신
- [ ] 홈 재진입/탭 전환 회귀 없음 (라운드 2 핵심: latched payload 회귀 봉쇄)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
