### PR TITLE
fix: 활동에너지 동기화 누락 보강 + HealthKit 진단 텔레메트리

### DIFF
--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -67,6 +67,8 @@ final class HomeViewModel: ObservableObject {
     private var calorieTooltipToken: UUID?
     private var didAutoShowCalorieTooltip = false
     private var hasSeenHealthKitAuthorized = false
+    /// foreground 단발 re-read의 연타 방지용 시간 가드(2초). observer/init read와는 무관.
+    private var lastForegroundReadAt: Date?
     
     private var loadingState: Loading = Loading()
     private let healthKitManager = HealthKitManager.shared
@@ -272,24 +274,72 @@ final class HomeViewModel: ObservableObject {
         healthKitManager.observeActiveEnergyBurned { [weak self] newKcal, authorized in
             guard let self = self else { return }
             DispatchQueue.main.async {
-                // 한 번이라도 허용이 관측되면 세션 내에서 유지(sticky).
-                // read 권한 데이터가 일시적으로 비는 구간에서도 권한 상태가 false로
-                // 되돌아가 i 아이콘이 깜빡이는 UI 플리커를 방지한다.
-                if authorized {
-                    self.hasSeenHealthKitAuthorized = true
-                    self.isHealthKitAuthorized = true
-                } else if !self.hasSeenHealthKitAuthorized {
-                    self.isHealthKitAuthorized = false
-                }
+                self.applyHealthKitResult(newKcal: Int(newKcal), authorized: authorized, source: .observerCallback)
+            }
+        }
+    }
 
-                self.currentKcal = Int(newKcal)
-                self.handleKcalUpdate(newKcal: Int(newKcal))
+    /// observe 콜백 / foreground 단발 re-read 양쪽에서 호출하는 공용 적용 헬퍼.
+    /// sticky 권한 갱신 + 표시값(currentKcal) 적용 + 서버 전송 + 권한 미허용 툴팁 + 이상 판정을 담당한다.
+    /// HealthKit 콜백은 이미 main으로 들어오므로 @MainActor 컨텍스트에서만 호출한다.
+    @MainActor
+    private func applyHealthKitResult(newKcal: Int, authorized: Bool, source: HealthKitReadSource) {
+        // 한 번이라도 허용이 관측되면 세션 내에서 유지(sticky).
+        // read 권한 데이터가 일시적으로 비는 구간에서도 권한 상태가 false로
+        // 되돌아가 i 아이콘이 깜빡이는 UI 플리커를 방지한다.
+        if authorized {
+            self.hasSeenHealthKitAuthorized = true
+            self.isHealthKitAuthorized = true
+        } else if !self.hasSeenHealthKitAuthorized {
+            self.isHealthKitAuthorized = false
+        }
 
-                // i 아이콘이 뜨는 케이스(권한 없음)에 한해, 최초 판단 시 1회 자동 노출
-                if !self.isHealthKitAuthorized && !self.didAutoShowCalorieTooltip {
-                    self.didAutoShowCalorieTooltip = true
-                    self.showCalorieTooltipMessage()
-                }
+        // 0 깜빡임 가드: "권한 없음 + 0"인 일시적 빈 결과로는 화면값을 0으로 덮지 않는다(이전 표시값 유지).
+        // 권한 OK면 무운동(0)·자정 리셋도 정상 반영. (App Group 저장 가드와 동일 의미를 표시값에도 적용)
+        if authorized || newKcal > 0 {
+            self.currentKcal = newKcal
+        }
+        // 서버 경로는 무변경: 가드와 무관하게 원래 newKcal을 그대로 전달.
+        // foreground 단발 re-read는 값이 실제로 바뀐 경우에만 부작용(서버 전송/말풍선)을 발생시킨다.
+        // (init/observer 경로는 기존과 동일하게 무조건 호출 — 동작 불변)
+        if source == .foregroundReRead {
+            if newKcal != previousKcal {
+                self.handleKcalUpdate(newKcal: newKcal)
+            }
+        } else {
+            self.handleKcalUpdate(newKcal: newKcal)
+        }
+
+        // i 아이콘이 뜨는 케이스(권한 없음)에 한해, 최초 판단 시 1회 자동 노출
+        if !self.isHealthKitAuthorized && !self.didAutoShowCalorieTooltip {
+            self.didAutoShowCalorieTooltip = true
+            self.showCalorieTooltipMessage()
+        }
+
+        // 이상 최종 판정(맥락 의존): "전엔 권한 있었는데 지금 비는" observer_gap.
+        // foreground/observer 경로만 대상. 정상0(권한 OK)·첫 진입 미허용은 무발생.
+        if source != .initRead,
+           self.hasSeenHealthKitAuthorized,
+           !authorized,
+           newKcal == 0 {
+            AnalyticsManager.shared.logEvent(event: HealthKitEvent.observerGap(source: source.rawValue))
+        }
+    }
+
+    /// scenePhase .active 진입 시 호출. observer를 재등록하지 않고 단발 read만 수행한다.
+    /// 짧은 시간 내 .active 연타(제어센터/알림센터 스와이프 등)에 대비해 2초 시간 가드를 둔다.
+    @MainActor
+    func refreshActiveEnergyIfNeeded() {
+        let now = Date()
+        if let last = lastForegroundReadAt, now.timeIntervalSince(last) < 2 { return }
+        lastForegroundReadAt = now
+
+        healthKitManager.refreshActiveEnergy(source: .foregroundReRead) { [weak self] kcal, authorized in
+            guard let self else { return }
+            // refreshActiveEnergy → readActiveEnergyBurned는 이미 main으로 콜백하지만,
+            // @MainActor 헬퍼 호출 보장을 위해 main 컨텍스트에서 적용한다.
+            DispatchQueue.main.async {
+                self.applyHealthKitResult(newKcal: Int(kcal), authorized: authorized, source: .foregroundReRead)
             }
         }
     }

--- a/DDanDDan/Presenter/Main/MainTabView.swift
+++ b/DDanDDan/Presenter/Main/MainTabView.swift
@@ -45,6 +45,7 @@ enum TabType: Int, CaseIterable {
 struct MainTabView: View {
     let coordinator: AppCoordinator
     @Perception.Bindable var store: StoreOf<MainTabReducer>
+    @Environment(\.scenePhase) private var scenePhase
     @State private var didSetupBindings = false
     
     @StateObject private var homeViewModel: HomeViewModel
@@ -108,6 +109,13 @@ struct MainTabView: View {
                 if !didSetupBindings {
                     setupViewModelBindings()
                     didSetupBindings = true
+                }
+            }
+            .onChange(of: scenePhase) { newPhase in
+                // foreground 복귀 시 observer가 끊겼어도 표시값을 따라잡도록 단발 re-read.
+                // HomeView가 아닌 항상 마운트되는 MainTabView에 둬서 탭 언마운트 갭을 피한다.
+                if newPhase == .active {
+                    homeViewModel.refreshActiveEnergyIfNeeded()
                 }
             }
             .onReceive(coordinator.$petChangedSession) { _ in

--- a/DDanDDan/Util/AnalyticsManager.swift
+++ b/DDanDDan/Util/AnalyticsManager.swift
@@ -313,3 +313,31 @@ enum SettingEvent: AnalyticsEvent {
         }
     }
 }
+
+// MARK: - HealthKit
+
+/// 활동에너지 read/observer 진단 텔레메트리. "이상 상황"에서만 발생시킨다(정상 0은 기록하지 않음).
+enum HealthKitEvent: AnalyticsEvent {
+    /// read 결과 데이터 없음 + 권한 거부(denied) 계열 HKError. errorNoData/정상0은 제외.
+    case readFailed(source: String, hkErrorCode: Int)
+    /// 이전에 권한이 관측됐는데 지금 read가 비는(authorized==false && kcal==0) "전엔 됐는데 지금 안 됨" 상황.
+    case observerGap(source: String)
+    /// enableBackgroundDelivery 실패.
+    case backgroundDeliveryFailed(hkErrorCode: Int)
+
+    var title: String {
+        switch self {
+        case .readFailed:               return "health_read_failed"
+        case .observerGap:              return "health_observer_gap"
+        case .backgroundDeliveryFailed: return "health_background_delivery_failed"
+        }
+    }
+
+    var parameter: [String: Any] {
+        switch self {
+        case let .readFailed(source, code):       return ["source": source, "hk_error_code": code]
+        case let .observerGap(source):            return ["source": source]
+        case let .backgroundDeliveryFailed(code): return ["hk_error_code": code]
+        }
+    }
+}

--- a/DDanDDan/Util/HealthKitManager.swift
+++ b/DDanDDan/Util/HealthKitManager.swift
@@ -9,6 +9,21 @@ import Foundation
 import HealthKit
 import UserNotifications
 
+// HealthKitManager는 iOS/watchOS 양 타겟에서 컴파일된다.
+// 진단 텔레메트리(Crashlytics/Analytics/UIApplication)는 iOS 전용 의존성이므로
+// Firebase가 링크되는 iOS 타겟에서만 컴파일한다(watch 타겟은 해당 모듈 미링크).
+#if canImport(FirebaseCrashlytics)
+import UIKit
+import FirebaseCrashlytics
+#endif
+
+/// 활동에너지 read 호출의 출처. 텔레메트리에서 호출 경로를 구분하기 위해 사용한다.
+enum HealthKitReadSource: String {
+    case initRead          // observe 등록 직후 1회 read
+    case observerCallback  // HKObserverQuery 콜백
+    case foregroundReRead  // scenePhase .active 재조회
+}
+
 class HealthKitManager: ObservableObject {
     static let shared = HealthKitManager()
     
@@ -62,14 +77,14 @@ class HealthKitManager: ObservableObject {
 
         // 등록 시점에 한 번 즉시 read를 호출해 권한 상태와 현재 칼로리를 갱신한다.
         // (HKObserverQuery는 데이터 변경이 없으면 callback이 안 올 수 있음)
-        readAndReport(completion: completion)
+        readAndReport(source: .initRead, completion: completion)
 
         // HKObserverQuery의 completionHandler는 반드시 호출해야 한다.
         // 미호출 시 iOS가 백그라운드 전달 재시도(3회) 후 업데이트 전달을 중단한다.
         let query = HKObserverQuery(sampleType: energyBurnedType, predicate: nil) { [weak self] _, completionHandler, error in
             defer { completionHandler() }
             guard error == nil else { return }
-            self?.readAndReport(completion: completion)
+            self?.readAndReport(source: .observerCallback, completion: completion)
         }
 
         activeObserverQuery = query
@@ -79,8 +94,8 @@ class HealthKitManager: ObservableObject {
         }
     }
 
-    private func readAndReport(completion: @escaping (Double, Bool) -> Void) {
-        readActiveEnergyBurned { [weak self] kcal, authorized in
+    private func readAndReport(source: HealthKitReadSource, completion: @escaping (Double, Bool) -> Void) {
+        readActiveEnergyBurned(source: source) { [weak self] kcal, authorized in
             // 권한이 확인됐거나 유의미한 데이터가 있을 때만 App Group에 저장.
             // 권한 없거나 일시적으로 데이터가 비는 경우 0으로 덮어쓰지 않도록 방어.
             if authorized || kcal > 0 {
@@ -89,14 +104,39 @@ class HealthKitManager: ObservableObject {
             completion(kcal, authorized)
         }
     }
-    
+
+    /// foreground 복귀 등 명시적 시점에 호출하는 단발 re-read.
+    /// ObserverQuery를 재등록하지 않고 readActiveEnergyBurned만 1회 실행한다.
+    /// (stop→execute 레이스·중복 등록 회피)
+    func refreshActiveEnergy(source: HealthKitReadSource,
+                             completion: @escaping (Double, Bool) -> Void) {
+        guard healthStore != nil else {
+            completion(0, false)
+            return
+        }
+        readAndReport(source: source, completion: completion)
+    }
+
     func enableBackgroundMode() async {
         guard let healthStore = healthStore else { return }
-        
+
         do {
             try await healthStore.enableBackgroundDelivery(for: energyBurnedType, frequency: .hourly)
         } catch let error {
-            print("Failed to enableBackgroundDelivery \(error)")
+            #if canImport(FirebaseCrashlytics)
+            // 백그라운드 전달 활성화 실패는 명백한 이상 → non-fatal + Analytics로 기록.
+            let hkErrorCode = (error as? HKError)?.code.rawValue ?? -1
+            AnalyticsManager.shared.logEvent(event: HealthKitEvent.backgroundDeliveryFailed(hkErrorCode: hkErrorCode))
+
+            // UIApplication.backgroundRefreshStatus는 main-thread-only이므로 main hop 후 수집.
+            let backgroundRefreshStatus = await MainActor.run {
+                UIApplication.shared.backgroundRefreshStatus.rawValue
+            }
+            let crashlytics = Crashlytics.crashlytics()
+            crashlytics.setCustomValue(hkErrorCode, forKey: "hk_error_code")
+            crashlytics.setCustomValue(backgroundRefreshStatus, forKey: "hk_background_refresh_status")
+            crashlytics.record(error: error)
+            #endif
         }
     }
 
@@ -112,7 +152,8 @@ class HealthKitManager: ObservableObject {
     /// read 권한 추론에서는 사용하지 않는다.
     /// 첫날 운동 0인 사용자는 errorNoData로 인해 false positive가 날 수 있으나,
     /// 안내 툴팁 노출이라 사용자 영향은 제한적.
-    func readActiveEnergyBurned(completion: @escaping (Double, Bool) -> Void) {
+    func readActiveEnergyBurned(source: HealthKitReadSource = .observerCallback,
+                                completion: @escaping (Double, Bool) -> Void) {
         guard let healthStore = healthStore else {
             completion(0, false)
             return
@@ -123,11 +164,12 @@ class HealthKitManager: ObservableObject {
 
         let predicate = HKQuery.predicateForSamples(withStart: startOfDay, end: now, options: .strictStartDate)
 
-        let query = HKStatisticsQuery(quantityType: energyBurnedType, quantitySamplePredicate: predicate, options: .cumulativeSum) { _, result, error in
+        let query = HKStatisticsQuery(quantityType: energyBurnedType, quantitySamplePredicate: predicate, options: .cumulativeSum) { [weak self] _, result, error in
             var resultCount = 0.0
             var errorDenied = false
 
-            if let hkError = error as? HKError {
+            let hkError = error as? HKError
+            if let hkError {
                 switch hkError.code {
                 case .errorAuthorizationDenied, .errorNoData:
                     errorDenied = true
@@ -138,8 +180,6 @@ class HealthKitManager: ObservableObject {
 
             if let sum = result?.sumQuantity() {
                 resultCount = sum.doubleValue(for: HKUnit.kilocalorie())
-            } else if let error {
-                print("Failed to fetch active energy burned = \(error.localizedDescription)")
             }
 
             // 데이터가 들어왔으면 권한이 있다는 가장 강한 증거 → 다른 신호 무시.
@@ -151,13 +191,38 @@ class HealthKitManager: ObservableObject {
                 authorized = !errorDenied
             }
 
+            // 진단 텔레메트리: 데이터 없음 + denied 계열(errorAuthorizationDenied)에서만 기록.
+            // errorNoData(첫날 무운동과 모호)·정상 0은 침묵 → 맥락 의존 판정은 HomeViewModel이 담당.
+            #if canImport(FirebaseCrashlytics)
+            if resultCount == 0, let hkError, hkError.code == .errorAuthorizationDenied {
+                self?.reportReadFailure(source: source, hkError: hkError)
+            }
+            #endif
+
             DispatchQueue.main.async {
                 completion(resultCount, authorized)
             }
         }
-        
+
         healthStore.execute(query)
     }
+
+    #if canImport(FirebaseCrashlytics)
+    /// read 권한 거부(denied) 계열 실패만 non-fatal + Analytics로 기록한다. (iOS 전용)
+    private func reportReadFailure(source: HealthKitReadSource, hkError: HKError) {
+        let hkErrorCode = hkError.code.rawValue
+        AnalyticsManager.shared.logEvent(
+            event: HealthKitEvent.readFailed(source: source.rawValue, hkErrorCode: hkErrorCode)
+        )
+
+        let crashlytics = Crashlytics.crashlytics()
+        let authStatus = healthStore?.authorizationStatus(for: energyBurnedType).rawValue ?? -1
+        crashlytics.setCustomValue(authStatus, forKey: "hk_auth_status")
+        crashlytics.setCustomValue(hkErrorCode, forKey: "hk_error_code")
+        crashlytics.setCustomValue(source.rawValue, forKey: "hk_source")
+        crashlytics.record(error: hkError)
+    }
+    #endif
     
     func readThreeDaysTotalKcal(completion: @escaping (Double) -> Void) {
         guard let healthStore = healthStore else {


### PR DESCRIPTION
## 배경 (CS)
"건강 앱 활동에너지 읽기를 허용했는데 갑자기 동기화가 안 된다"는 문의. 권한 토글은 정상(ON)이었고, 진짜 원인은 **홈 표시값(`currentKcal`)이 `HKObserverQuery` 단일 경로에만 의존 + foreground 재조회 부재**였다. observer가 한 번 끊기면(Apple 문서화된 as-designed 실패모드 / 백그라운드 앱 새로고침 OFF / 권한 grant는 observer를 발화시키지 않음) **cold launch 전까지 값이 멈춘다** → "원래 됐는데 갑자기 안 됨".

## 변경 (P1 — 근본 수정)
- **`MainTabView`**: `@Environment(\.scenePhase)` + `.onChange` → `.active` 복귀 시 `refreshActiveEnergyIfNeeded()`. HomeView가 아닌 MainTabView에 둔 이유는 홈 탭 비활성 시 `HomeView`가 언마운트돼 `.active`를 놓치기 때문.
- **`HealthKitManager`**: observer 재등록(stop→execute) 없이 read만 하는 `refreshActiveEnergy(source:)` 신설 → 레이스/중복 등록 회피.
- **`HomeViewModel`**: observe/foreground 공용 `applyHealthKitResult(...)` 추출. **0 깜빡임 가드**(권한 일시 단절 시 표시값 stale 유지), 2초 디바운스, foreground 복귀는 **값이 실제 변할 때만** 서버 전송·말풍선 발생(reopen마다 말풍선 뜨는 회귀 방지).

## 변경 (P2 — 진단 텔레메트리)
`os_log`는 현장에서 안 보이므로 팀이 이미 쓰는 Firebase로 전송:
- **Analytics**: `health_observer_gap`(전엔 됐는데 지금 빔 — 핵심), `health_read_failed`, `health_background_delivery_failed`. **정상 0(권한 OK+무운동)은 미발생 → 노이즈 0.**
- **Crashlytics non-fatal**: `hk_auth_status` / `hk_error_code` / `hk_source` / `hk_background_refresh_status`.
- watch 타겟 빌드 보호 위해 Firebase import는 `#if canImport(FirebaseCrashlytics)` 분기(watch는 read 로직만, 텔레메트리 제외).

## 자체 리뷰
Pass with minor (Blocker 0 / Major 0). 동시성·0깜빡임·observer 레이스·`#if` 분기·M1(말풍선 회귀) 모두 처리.

## 검증
- [x] `build_sim`(scheme DDanDDan, iPhone 17 Pro) 성공, errors 0
- [ ] 실기기: 백그라운드 중 운동 → foreground 복귀 시 표시값 따라잡음
- [ ] 권한 거부 시 0 깜빡임 없음 + 칼로리 툴팁 1회
- [ ] Firebase DebugView에서 이상 시에만 이벤트 발생(정상 0 무발생)

## 후속(P3, 범위 밖)
- `isAuthorized()` read 부적합(`!= .notDetermined`로 정정)
- 시간기반 observer-gap 측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Bug Fixes**
  * 앱 포그라운드 전환 시 활동 에너지 데이터 동기화 정확도 개선
  * 중복된 데이터 새로고침 요청 방지
  * HealthKit 권한 상태 안정성 향상

* **Chores**
  * 내부 진단 및 오류 추적 로깅 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->