### PR TITLE
chore: Codex 하네스 설정 추가

### DIFF
--- a/.agents/skills/ios-feature/SKILL.md
+++ b/.agents/skills/ios-feature/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: ios-feature
+description: ddan-ddan-ios의 iOS/SwiftUI 기능 추가, 버그 수정, 리팩터링, PR 리뷰 코멘트 반영 작업을 ios-architect → swift-implementer → swift-reviewer 3인 에이전트 팀으로 수행하는 오케스트레이터. ddan-ddan-ios 프로젝트의 어떤 코드 변경 요청(예 "Home에 X 버튼 추가해줘", "Setting의 Y 버그 수정", "PR 리뷰 반영해줘", "이 화면 다시 그려줘", "이 기능 보완해줘")에서도 반드시 사용. 단순 질문/탐색만 할 때는 사용 안 함.
+---
+
+# ios-feature — ddan-ddan-ios 기능/버그/리뷰 오케스트레이터
+
+ddan-ddan-ios 프로젝트의 모든 코드 변경 작업을 3인 에이전트 팀이 협업하여 처리한다.
+
+**팀 구성:**
+- `ios-architect` — 변경 계획 (읽기만)
+- `swift-implementer` — 실제 코드 작성/수정
+- `swift-reviewer` — 자체 리뷰
+
+**실행 모드:** 에이전트 팀 (`TeamCreate` + `TaskCreate` + `SendMessage`)
+
+## Phase 0: 컨텍스트 확인
+
+워크플로우 진입 시:
+
+1. `_workspace/` 디렉토리 존재 여부 확인.
+2. **존재 + 사용자가 같은 작업의 부분 수정 요청** ("리뷰어 의견 반영해서 다시", "X 부분만 다시"):
+   → **부분 재실행 모드 (보수 조건부).**
+   - 변경이 다음 "계약(contract)" 영역에 영향을 주지 않으면 해당 에이전트만 재호출, 기존 산출물 유지.
+   - **계약 변경 시 architect도 함께 재실행 (최소 Phase 1 재평가):**
+     - DI / `RepositoryDependency` 등록 추가·삭제·이름 변경
+     - `AppCoordinator` 라우팅 / `*Path` enum / 화면 등록 / 딥링크 핸들링
+     - HealthKit / WatchConnectivity 권한·세션 상태·동시성 계약
+     - watchOS ↔ iOS 메시지 키·App Group 키
+     - TCA Reducer State 형태 (Equatable 깨짐) / Reducer ↔ ViewModel 전환
+     - 네트워크 endpoint contract (`PathString` 추가/변경)
+   - 위 영역과 무관한 "텍스트 카피 수정", "스타일 미세조정", "이벤트명 오타", "주석/문서 보강" 등은 부분 재실행으로 안전.
+3. **존재 + 사용자가 새 입력 제공** (다른 기능 요청):
+   → 기존 `_workspace/`를 `_workspace_prev/`로 이동, 새 디렉토리 생성, **초기 실행**.
+4. **미존재**: `_workspace/` 생성 후 **초기 실행**.
+
+## Phase 1: 요구사항 분석 / 명료화
+
+오케스트레이터(메인)가 수행. 팀 생성 전.
+
+1. 사용자 요청을 한 줄로 요약.
+2. 영향 범위가 명백히 큰 경우(전체 리팩터, 5개 화면 동시 변경 등) **사용자에게 분할 제안**.
+3. 모호한 부분 1~2개를 짧게 질문 (이 단계에서 시간을 너무 쓰지 않는다).
+4. 작업 유형 분류:
+   - **a) 신규 기능 추가** — 전체 파이프라인.
+   - **b) 버그 수정** — 전체 파이프라인 (architect는 원인 분석에 집중).
+   - **c) PR 리뷰 코멘트 반영** — architect 생략 가능, reviewer가 코멘트를 분류 → implementer가 반영 → reviewer 재확인.
+   - **d) 단순 리팩터** — 전체 파이프라인.
+
+## Phase 2: 팀 구성 및 작업 할당
+
+`TeamCreate` 로 팀 구성:
+- 팀 이름: `ios-feature-team`
+- 멤버: `ios-architect`, `swift-implementer`, `swift-reviewer`
+- 모든 에이전트 호출 시 `model: "opus"` 명시.
+
+`TaskCreate` 로 작업 등록 (의존성 포함):
+1. **architect 작업** — "변경 계획 작성, 출력: `_workspace/01_architect_plan.md`"
+2. **implementer 작업** — "계획대로 구현, 출력: `_workspace/02_implementer_changes.md`" (architect 작업에 blockedBy)
+3. **reviewer 작업** — "변경 자체 리뷰, 출력: `_workspace/03_reviewer_findings.md`" (implementer 작업에 blockedBy)
+4. **implementer 후속 작업** — "리뷰 반영" (reviewer 결과 Blocker/Major 있을 때만 등록)
+
+**PR 리뷰 반영 모드(c)** 일 때:
+1. reviewer가 먼저 코멘트 분류 (`_workspace/00_review_triage.md`).
+2. implementer가 반영.
+3. reviewer가 재확인.
+
+## Phase 3: 자체 조율 모니터링
+
+팀원들이 `SendMessage`/`TaskUpdate`로 자체 조율한다. 오케스트레이터는:
+
+- 진행 상황을 가끔 `TaskList` 로 점검.
+- 팀원 간 핑퐁(implementer ↔ reviewer 3회 이상)이면 architect 중재 요청.
+- 사용자 추가 입력이 필요한 경우(권한, 디자인 결정) 즉시 사용자에게 질문.
+
+## Phase 4: 결과 종합
+
+모든 작업 완료 후:
+
+1. `_workspace/03_reviewer_findings.md`의 종합 판정 확인.
+2. 사용자에게 **2~3문장 요약** 보고:
+   - 어떤 파일이 어떻게 바뀌었는지 (전체 목록 X, 핵심 1~3개)
+   - 미해결 / 후속 작업 (있다면)
+   - 사용자가 다음에 해야 할 것 (Xcode 빌드, 디바이스 테스트 등)
+3. **commit/PR 메시지 안 1줄 제안** (한국어, 기존 컨벤션 따름).
+4. `TeamDelete`로 팀 정리.
+
+## Phase 5: 피드백 수집
+
+사용자 응답 후:
+- 명시적 추가 요청이 있으면 Phase 0부터 (부분 재실행 모드).
+- 동일 유형 피드백이 반복되면 (2회+) 하네스 진화 제안 (AGENTS.md 변경 이력에 기록 + 관련 스킬/에이전트 수정).
+
+## 데이터 전달 프로토콜
+
+- **태스크 기반**: 진행 상황과 의존성. `TaskCreate`/`TaskUpdate`.
+- **파일 기반**: 산출물. `_workspace/` 하위.
+  - `01_architect_plan.md`
+  - `02_implementer_changes.md`
+  - `03_reviewer_findings.md`
+  - `00_review_triage.md` (PR 리뷰 모드 시)
+- **메시지 기반**: 즉시 알림/질문. `SendMessage`.
+
+## 에러 핸들링
+
+- **architect가 요구사항 모호로 막힘** → 사용자에게 질문 1~2개 → 답 받으면 architect 재시작.
+- **implementer가 컴파일 의심** → 일단 구현하고 02_implementer_changes.md "미완"에 명시. 사용자가 빌드 검증.
+- **reviewer ↔ implementer 무한 루프** → architect 중재. 그래도 안 되면 사용자 결정.
+- **에이전트 1회 재시도 후 재실패** → 해당 산출물 누락한 채 진행, 보고서에 명시.
+
+## 테스트 시나리오
+
+**정상 흐름 (신규 기능):**
+사용자: "Setting에 알림 시간대 설정 화면 추가해줘"
+1. Phase 1: 요구사항 명료화 — "특정 시간 푸시인지, 시간대 외 처리는?" 질문.
+2. Phase 2: 팀 구성, 3개 작업 등록.
+3. architect → 계획 (Setting 디렉토리에 새 View/ViewModel + Network endpoint).
+4. implementer → 4개 파일 생성/수정 + RepositoryDependency 등록.
+5. reviewer → minor 1개(접근성 라벨 추가 제안), Pass with minor.
+6. implementer → minor 반영.
+7. Phase 4: 사용자에게 요약 + 빌드 안내.
+
+**에러 흐름 (요구사항 모호):**
+사용자: "친구 화면 좀 개선해줘"
+1. Phase 1: 너무 모호 → architect에게 넘기지 않고 사용자에게 "어떤 부분(목록 정렬/카드 디자인/검색)인지" 질문.
+2. 사용자 답변 후 정상 흐름.
+
+**PR 리뷰 반영 모드:**
+사용자: "[GitHub PR URL의 코멘트들 붙여넣기] 반영해줘"
+1. Phase 1: 작업 유형 (c)로 분류.
+2. reviewer 먼저 코멘트 트리아지 → `00_review_triage.md`.
+3. implementer 반영 → `02_implementer_changes.md`.
+4. reviewer 재확인.
+5. Phase 4: commit 메시지 안 (`fix: PR 리뷰 반영 (...)`) 제안.

--- a/.agents/skills/swift-conventions/SKILL.md
+++ b/.agents/skills/swift-conventions/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: swift-conventions
+description: ddan-ddan-ios 프로젝트의 Swift/SwiftUI 코드 컨벤션, 디렉토리 구조, 의존성 주입(Dependencies), 화면 사이즈 어댑터(.adjusted), Asset 색상 참조, 한국어 커밋 메시지 규칙을 담는 가이드. ddan-ddan-ios 프로젝트의 어떤 Swift 파일을 추가/수정/리뷰하든 항상 이 스킬을 참조할 것. TCA Reducer, Coordinator, ViewModel, Repository, Network, HealthKit, WatchConnectivity 작업 시 반드시 트리거.
+---
+
+# swift-conventions — ddan-ddan-ios
+
+ddan-ddan-ios 프로젝트의 Swift 코드 작성 시 따라야 할 컨벤션. **계획·구현·리뷰의 모든 에이전트가 참조**한다.
+
+## 1. 디렉토리 구조
+
+```
+DDanDDan/
+├── DDanDDanApp.swift               # @main, app entry
+├── AppCoordinator.swift            # navigation root
+├── DeepLinkManager.swift           # URL/Universal Link 처리
+├── Entity/                         # 도메인별 모델 (Auth/Cheer/Friend/Home/Pet/Rank/User/Error)
+├── Network/                        # Alamofire 기반 *Network.swift + 인터셉터
+├── Repository/                     # 도메인별 Repository (DI 진입점)
+│   └── Dependencies/RepositoryDependency.swift  # DependencyValues extension
+├── Presenter/                      # 화면 + ViewModel (또는 TCA Reducer)
+│   ├── Components/                 # 공용 SwiftUI 컴포넌트
+│   ├── Home / Friends / Login / Main / Onboarding / Rank / Setting / Splash
+└── Util/                           # AnalyticsManager, HealthKitManager,
+                                    # WatchConnectivityManager, RealtimeDBManager,
+                                    # RemoteConfigManager, UserDefaultValue, Extension/, Event/
+```
+
+**규칙:**
+- 새 화면은 `Presenter/{Domain}/` 하위에 배치.
+- 공용 UI 컴포넌트(다른 화면에서도 재사용 가능)는 `Presenter/Components/`.
+- Repository는 1도메인 1파일(`{Domain}Repository.swift`).
+- Watch 앱 코드는 `DdanDdan_Watch Watch App/` 별도 타겟.
+
+## 2. 아키텍처 — TCA + MVVM 혼재
+
+**현실:** 일부는 TCA(`Reducer` + `Store`), 일부는 MVVM(`ViewModel`). 혼재된 상태이고, 함부로 한쪽으로 통일하지 않는다.
+
+**판단 규칙:**
+- 같은 디렉토리의 인접 파일을 본다. `HomeView`가 `HomeViewModel`을 쓰면 같은 도메인의 새 화면도 ViewModel 패턴.
+- 리스트/랭킹/친구 등 신규로 도입되는 부분에 TCA가 더 많이 쓰임 (e.g. `RankViewReducer`).
+- 새 화면을 추가할 때 패턴 선택이 모호하면 architect가 판단.
+
+**Coordinator:** `AppCoordinator`가 모든 navigation을 관리. 새 화면 push 시 `enum {Domain}Path: Hashable`을 정의하고 navigation destination 등록.
+
+## 3. 의존성 주입 — `Dependencies` 패키지
+
+```swift
+import Dependencies
+
+extension DependencyValues {
+    var fooRepository: FooRepository {
+        get { self[FooRepository.self] }
+        set { self[FooRepository.self] = newValue }
+    }
+}
+```
+
+신규 Repository 추가 시 **반드시** `RepositoryDependency.swift`에 등록. 사용처에서는 `@Dependency(\.fooRepository)`.
+
+## 4. SwiftUI 화면 컨벤션
+
+**SE 디바이스 적응:**
+```swift
+private let isSEDevice = UIScreen.isSESizeDevice
+// padding(.horizontal, isSEDevice ? 28 : 32.adjustedWidth)
+// padding(.top, isSEDevice ? 16 : 54.adjustedHeight)
+```
+
+**`.adjusted`, `.adjustedWidth`, `.adjustedHeight`** — `Util/Extension/Adjusted+.swift` 정의. 디자인 기준 화면(보통 iPhone 13/14)의 값을 실제 디바이스에 비례 조정. 새 레이아웃 값에 일관되게 적용.
+
+**색상:** `Color(.backgroundBlack)` 같이 Asset Catalog 참조. 하드코딩 hex 금지.
+
+**컴포넌트 우선:** `Presenter/Components/`의 `DialogView`, `ToastView`, `TooltipView`, `GreenButton`, `HomeButton`, `NavigationBarView` 등 먼저 검토 후 재사용. 새로 만들기 전에 grep.
+
+**Lottie:** `import Lottie` — 게임/펫 애니메이션에 활용.
+
+**오버레이/토스트:** `TransparentOverlayView` + `ToastView` 조합 사용 (HomeView 참고).
+
+## 5. 동시성 / 메모리
+
+- `@StateObject` (소유) vs `@ObservedObject` (외부 주입) 구분.
+- `Task { }` 내부에서 self 캡처 시 명시적 `[weak self]` (특히 `ViewModel`이 `ObservableObject`인 경우).
+- HealthKit / WatchConnectivity 콜백은 보통 백그라운드 큐 → UI 업데이트는 `MainActor`/`DispatchQueue.main`.
+- `@Sendable` 클로저 안 self 캡처 시 actor 격리 주의.
+- `ObserverQuery` 등 long-running query는 deinit에서 해제(혹은 명시적 stop).
+
+## 6. 네트워크 / 에러
+
+- Alamofire 기반 `*Network.swift`. `NetworkManager`가 공통.
+- `TokenInterceptor` + `TokenRefreshManager`로 자동 갱신.
+- 에러 모델: `Entity/Error/ServerErrorResponse`.
+- 네트워크 이벤트는 `Util/Event/NetworkEvent`로 Analytics 기록.
+
+## 7. 분석 / 외부 SDK
+
+- `AnalyticsManager` (Firebase GA) — 화면 진입/주요 이벤트 기록.
+- `RealtimeDBManager`, `RemoteConfigManager` (Firebase) — 강제 업데이트 등.
+- `KakaoSDK` — 로그인.
+- `ChottuLinkSDK` — 친구 초대 딥링크.
+
+## 8. 파일 헤더
+
+기존 파일과 동일 형식:
+```swift
+//
+//  FileName.swift
+//  DDanDDan
+//
+//  Created by {git config user.name} on {YYYY-MM-DD or M/D/YY}.
+//
+```
+
+날짜 형식은 인접 파일과 맞춘다 (`9/26/24` 또는 `2025/04/01` 둘 다 존재).
+
+## 9. 한국어 / 영어
+
+- **사용자 가시 문구**: 한국어 ("문의하기", "친구 초대", "건강 데이터 권한이 필요해요").
+- **코드 식별자**: 영어 (`HomeViewModel`, `friendCardRepository`).
+- **주석/docstring**: 한국어 OK. 최근 PR 리뷰 반영 커밋들은 한국어 docstring을 사용.
+
+## 10. 커밋 메시지
+
+`git log`에서 보이는 패턴:
+- `feat: {한국어 또는 영어}` — 신규
+- `fix: {간단 설명}` — 수정
+- `chore: {한국어}` — 잡일 (버전 업, 이벤트 추가)
+- `docs: {한국어}` — 문서/주석
+- 본문은 보통 한국어. 이슈/PR 번호 직접 표기보다 PR 본문에 의존.
+
+## 11. 도메인별 추가 가이드
+
+세부 패턴은 references/에 분리:
+- `references/healthkit.md` — HealthKit 권한·쿼리·ObserverQuery 패턴 (HealthKit 변경 시 반드시 읽기)
+- `references/watch-connectivity.md` — iOS↔watchOS WCSession 메시징 (Watch 동기화 변경 시 반드시 읽기)
+- `references/deeplink.md` — DeepLinkManager / Universal Link / ChottuLink (딥링크 작업 시 반드시 읽기)

--- a/.agents/skills/swift-conventions/references/deeplink.md
+++ b/.agents/skills/swift-conventions/references/deeplink.md
@@ -1,0 +1,49 @@
+# 딥링크 패턴 (ddan-ddan-ios)
+
+친구 초대를 ChottuLinkSDK 동적링크로 처리. iOS↔Android 호환성과 cold/warm start 처리에 주의.
+
+## 1. 진입점
+
+- `DDanDDan/DeepLinkManager.swift` — `DeepLinkType` enum + `pendingDeepLink` Combine Publisher.
+- `InviteLinkBuilder` — ChottuLink 동적 링크 생성.
+- App에서 URL 수신 → `DeepLinkManager.handleFriendInvite(code:)` 호출 → `pendingDeepLink` 발행.
+
+## 2. URL 파싱 — `metadata["originalURL"]` 우선 + `code` 쿼리 파라미터 추출
+
+- 최근 fix(`ebee7e9 fix: metadata["originalURL"]을 우선 사용하고 link를 fallback으로 변경`).
+- ChottuLink resolve 결과에서 metadata와 link 두 곳에 URL이 있을 수 있음. **metadata.originalURL을 우선**, 없으면 link로 fallback.
+- `f648601 fix: 딥링크 친구 초대 코드 추출 시 resolve된 URL 사용` — 단축 URL을 resolve한 뒤, **`code` 쿼리 파라미터에서 친구 코드를 추출**한다.
+- 추출 규칙: `URLComponents(url:resolvingAgainstBaseURL: false).queryItems?.first(where: { $0.name == "code" })?.value`.
+- 링크 생성 측 (`InviteLinkBuilder.makeInviteURL`)이 `URLQueryItem(name: "code", value: trimmed)` 으로 만들기 때문에 추출도 동일 키를 사용해야 함. 키가 바뀌면 양쪽 동시 변경.
+
+## 3. iOS↔Android 호환
+
+- `36bd60b fix: iOS↔Android 친구추가 딥링크 호환성 수정` 맥락 참고.
+- `setIOSBehaviour(.app)`, `setAndroidBehaviour(.app)` 양쪽 설정.
+- 도메인: `ddanddan.chottu.link`.
+
+## 4. Cold start / Warm start (현재 구현 기준)
+
+- App이 종료된 상태에서 딥링크로 진입(cold start)할 때 vs 백그라운드에서 복귀(warm start).
+- **현재 동작:** `DeepLinkManager.handleFriendInvite(code:)` 가 두 가지를 동시에 수행한다.
+  1. `@Published var pendingDeepLink` 에 **마지막 값을 덮어씀** (큐잉 아님 — 두 개 이상의 딥링크가 짧은 시간에 들어오면 마지막 것만 남음).
+  2. `NotificationCenter.default.post(name: .friendInviteDeepLink, object: code)` 로 알림 발행 — **실제 소비 경로는 NotificationCenter 측이 메인**.
+- **알려진 한계 (코드 변경 시 함께 검토):**
+  - `pendingDeepLink` 는 `@Published` 메모리 전용. **앱 강제 종료 후 재기동 시 유실**. 영속화가 필요하면 UserDefaults 등으로 보강.
+  - `clearPendingDeepLink()` 메소드가 정의되어 있지만 **현재 코드 어디에서도 호출되지 않음**. 만약 `pendingDeepLink` 기반 흐름을 활용하려면 로그인 성공/실패 시점 등에서 명시적으로 호출해야 함.
+- **변경 제안 시 결정:** (A) 기존 NotificationCenter 흐름을 유지하고 `pendingDeepLink` 를 제거, 또는 (B) `pendingDeepLink` 를 진짜 큐로 만들고 cold-start 영속화 + clear 호출 경로 도입. 한쪽으로 정리하지 않으면 두 메커니즘이 공존하여 디버깅 난도가 올라간다.
+
+## 5. Universal Link
+
+- Apple App Site Association(AASA) 등록.
+- `Info.plist`의 Associated Domains 확인.
+- Universal link 도착 시 `application(_:continue:restorationHandler:)` 경로 → DeepLinkManager로 위임.
+
+## 6. 체크리스트 (변경 시)
+
+- [ ] URL 파싱 — metadata.originalURL 우선, link fallback.
+- [ ] cold/warm start 양 경로 검증.
+- [ ] iOS와 Android 양쪽 동작 확인 (베타 빌드).
+- [ ] 처리 후 `pendingDeepLink` 정리.
+- [ ] 로그인 전/후 진입 모두 시뮬.
+- [ ] 잘못된 코드/만료 링크의 에러 UX.

--- a/.agents/skills/swift-conventions/references/healthkit.md
+++ b/.agents/skills/swift-conventions/references/healthkit.md
@@ -1,0 +1,56 @@
+# HealthKit 패턴 (ddan-ddan-ios)
+
+이 프로젝트는 HealthKit으로 `activeEnergyBurned`(소모 칼로리)를 읽어 펫의 성장 로직과 연결한다. 사용자 권한 거부/부분 허용 케이스가 빈번하므로 권한 처리에 특별히 주의.
+
+## 1. 진입점
+
+`DDanDDan/Util/HealthKitManager.swift` (싱글톤). 모든 HealthKit 호출은 이 매니저를 통한다.
+
+## 2. 권한 추론의 함정 (현재 구현 한계 포함)
+
+- `HKHealthStore.authorizationStatus(for:)`는 **read 권한 상태를 정확히 알려주지 않는다.** Apple은 사용자 프라이버시 보호 차원에서 read 권한 상태를 노출하지 않음.
+- 따라서 `isAuthorized()`만 믿고 분기하면 잘못 판단할 수 있다.
+- **이상적인 패턴**: 실제 쿼리를 시도하고, 결과 데이터(0이거나 에러) + `authorizationStatus` 조합으로 판단.
+- **현재 구현의 한계:** `HealthKitManager.readActiveEnergyBurned(completion:)` 는 다음 세 케이스 모두에서 동일하게 `0`을 반환하여 구분이 불가능하다:
+  - `healthStore == nil` (HealthKit 미지원 디바이스)
+  - 쿼리 에러 (권한 거부 포함)
+  - 데이터가 정말 0kcal
+  에러를 문자열 로그로만 처리하고 `HKError.notAuthorized` 같은 타입 검사를 하지 않음. 또 `HomeViewModel` 은 사실상 `isAuthorized()` 호출에만 의존.
+- **권장 개선** (변경할 일이 있을 때): `readActiveEnergyBurned` 시그니처를 `Result<Double, HKError>` 또는 `async throws -> Double?` 로 바꾸고, "데이터 없음(0)"과 "권한 거부"·"디바이스 미지원"을 구분 가능하게. 그래야 권한 미허용 시 안내 툴팁(`feat: 건강 데이터 미허용 시 칼로리 영역에 안내 툴팁 추가`)이 false-positive 없이 노출된다.
+- 최근 PR(`d545146 fix: PR 리뷰 반영 (권한 추론/ObserverQuery/접근성)`, `e20d630 docs: readActiveEnergyBurned 권한 추론 우선순위 docstring 정정`) 컨텍스트 참고.
+
+## 3. ObserverQuery 라이프사이클
+
+- `HKObserverQuery`는 long-running. `healthStore.execute(query)` 후 명시적으로 stop하지 않으면 계속 동작.
+- **`HealthKitManager`는 싱글톤(`shared`)이므로 deinit이 사실상 일어나지 않는다 — deinit 기반 cleanup에 의존하지 말 것.**
+- 화면이 사라질 때 `healthStore.stop(query)` 를 호출할 수 있는 **명시적 stop API** (예: `stopObserveActiveEnergyBurned()`) 를 매니저에 두고, `View`/`ViewModel` 의 lifecycle 훅(`.onDisappear` 또는 ViewModel deinit)에서 호출.
+- 신규 ObserverQuery 추가 시 매니저에 stop API를 함께 추가하지 않으면 콜백·리소스가 백그라운드에서 영구 동작하여 배터리·발열·중복 알림의 원인이 된다.
+- `enableBackgroundDelivery`는 백그라운드 갱신용. 권한 거부 또는 enable 실패 시 무조건 무시하지 말고, 최소한 OSLog로 기록하고 UX 정책을 정한다 (예: "권한 거부 시 안내 툴팁 노출").
+
+## 4. 백그라운드 호출 → 메인스레드 UI
+
+- ObserverQuery 콜백은 백그라운드 큐에서 호출됨.
+- ViewModel의 `@Published` 업데이트는 반드시 메인 액터:
+  ```swift
+  await MainActor.run { self.kcal = kcal }
+  // 또는 DispatchQueue.main.async { ... }
+  ```
+
+## 5. App Group 데이터 공유
+
+- 위젯/Watch와 데이터 공유 위해 App Group `UserDefaults`에 칼로리 저장.
+- 키 컨벤션 확인 후 추가 (기존 키와 충돌 금지).
+
+## 6. 권한 미허용 시 UX
+
+- 사용자 가시 안내가 필요한 경우 `TooltipView` 같은 컴포넌트 활용.
+- 최근 도입된 패턴: `feat: 건강 데이터 미허용 시 칼로리 영역에 안내 툴팁 추가` (4174e72).
+
+## 7. 체크리스트 (변경 시)
+
+- [ ] `Info.plist`의 `NSHealthShareUsageDescription` 메시지 확인.
+- [ ] 권한 추론을 단일 API에 의존하지 않는다.
+- [ ] ObserverQuery는 stop 경로가 있다.
+- [ ] 콜백 → UI 업데이트는 메인 액터.
+- [ ] 권한 거부 케이스의 UI 분기 (빈 상태 / 안내 / 재요청).
+- [ ] App Group 키 충돌 없음.

--- a/.agents/skills/swift-conventions/references/watch-connectivity.md
+++ b/.agents/skills/swift-conventions/references/watch-connectivity.md
@@ -1,0 +1,50 @@
+# WatchConnectivity 패턴 (ddan-ddan-ios)
+
+iOS 앱과 watchOS 앱 간 데이터 동기화. `WatchConnectivityManager` (싱글톤) 통해서만 사용한다.
+
+## 1. 진입점
+
+- `DDanDDan/Util/WatchConnectivityManager.swift` (iOS 측)
+- watchOS 측 대응 매니저는 `DdanDdan_Watch Watch App/` 하위.
+
+## 2. 메시지 종류
+
+| 함수 | 용도 | 보장 |
+|------|------|------|
+| `sendMessage(_:replyHandler:errorHandler:)` | 즉시 전송 (foreground) | reachable일 때만 |
+| `transferUserInfo(_:)` | 비동기, 보장 전달 (백그라운드 OK) | 활성화 후 모두 도달 |
+| `updateApplicationContext(_:)` | 마지막 상태 1개만 | 효율적 상태 동기화 |
+| `transferFile(_:)` | 파일 전송 | 큰 데이터 |
+
+**선택 기준:**
+- 실시간 단발 → `sendMessage`
+- 활동 데이터/이벤트 → `transferUserInfo`
+- "현재 상태"만 중요한 경우 → `updateApplicationContext`
+
+## 3. 메시지 키 컨벤션
+
+- 키 문자열을 enum/상수로 정의하여 iOS↔watchOS 양쪽에서 공유.
+- 새 키 추가 시 양쪽 모두 업데이트 (한쪽만 하면 무시되어 silent fail).
+
+## 4. 세션 활성화
+
+- 앱 시작 시 `WCSession.default.activate()` (init에서).
+- `sessionDidDeactivate`에서 다시 `activate()` 호출 (iOS 측 다중 watch 지원).
+
+## 5. 메인 액터 / 동시성
+
+- `didReceiveMessage`는 background queue에서 호출됨.
+- `@Published` 업데이트 또는 UI 변경은 반드시 메인 액터.
+
+## 6. 디버깅
+
+- `print(...)` 디버그 로그가 다수 존재 → 운영 코드에서는 OSLog로 점진 교체 권장.
+- watch와 통신 안되면: 시뮬레이터는 페어링 환경 다름 → 실기기 검증 필요.
+
+## 7. 체크리스트 (변경 시)
+
+- [ ] 새 메시지 키를 iOS와 watchOS 양쪽에 추가.
+- [ ] reachable 분기 (foreground sendMessage 시) — fallback으로 transferUserInfo 고려.
+- [ ] 백그라운드 콜백 → UI 업데이트는 메인 액터.
+- [ ] 큰 데이터(이미지 등)는 `transferFile` 사용.
+- [ ] 앱 종료 후 데이터 보존이 필요하면 App Group UserDefaults도 함께 갱신.

--- a/.agents/skills/swift-review-checklist/SKILL.md
+++ b/.agents/skills/swift-review-checklist/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: swift-review-checklist
+description: ddan-ddan-ios의 Swift/SwiftUI 코드 자체 리뷰 체크리스트. swift-reviewer 에이전트가 PR 직전 또는 외부 PR 리뷰 코멘트 반영 전에 사용한다. 코드 변경 검토, 자체 리뷰, PR 리뷰 반영, "리뷰 한번 해줘" 요청 시 반드시 트리거.
+---
+
+# swift-review-checklist — ddan-ddan-ios
+
+ddan-ddan-ios의 Swift/SwiftUI 코드를 자체 리뷰할 때 따라야 할 체크리스트. **swift-reviewer 에이전트가 항상 참조**한다. 본 프로젝트의 실제 PR 리뷰에서 반복 지적된 항목을 우선 정렬.
+
+## 0. 심각도 정의
+
+- **Blocker** — 크래시, 데이터 유실, 인증/보안 문제, 명확한 빌드 실패. → 반드시 수정.
+- **Major** — 메모리 누수, 동시성 결함, 접근성 결함, watchOS 동기화 누락, 권한 추론 오류. → 수정 강력 권고.
+- **Minor** — 컨벤션 위배, 명명, 가독성, 중복. → 제안.
+- **Nit** — 취향. → 무시 가능.
+
+## 1. 메모리 / 라이프사이클 [Major]
+
+- [ ] `Task { ... }` 내 self 캡처 시 `[weak self]` (특히 ObservableObject ViewModel).
+- [ ] `HKObserverQuery`, `WCSession` delegate, NotificationCenter observer는 해제 경로 존재.
+- [ ] `@StateObject` (소유) vs `@ObservedObject` (외부) 적절히 구분 — 잘못 쓰면 화면 갱신마다 재생성/누수.
+- [ ] 싱글톤(`HealthKitManager.shared` 등)에 누적 상태 있는지 — 로그아웃 시 정리되는지.
+
+## 2. 동시성 [Major]
+
+- [ ] HealthKit / WatchConnectivity / 네트워크 콜백 → UI 업데이트는 `@MainActor` 또는 `DispatchQueue.main`.
+- [ ] `@Published` 변경은 메인 액터.
+- [ ] actor 외부에서 actor-isolated 프로퍼티 접근 시 `await`.
+- [ ] `@Sendable` 클로저에서 self 캡처 시 actor 격리 일관성.
+
+## 3. HealthKit [Major] — 본 프로젝트 빈번 이슈
+
+- [ ] 권한 상태를 `authorizationStatus(for:)` 단일 API로만 추론하지 않는다 (read 권한은 정확히 노출되지 않음).
+- [ ] 실제 쿼리 결과 + status 조합으로 판단.
+- [ ] ObserverQuery는 stop/cleanup 경로 있음.
+- [ ] 권한 거부 시 UI 폴백(빈 상태, 안내 툴팁) 존재.
+- [ ] `Info.plist` Usage Description 메시지 적절.
+- 자세히: `swift-conventions/references/healthkit.md`.
+
+## 4. WatchConnectivity [Major]
+
+- [ ] 새 메시지 키가 iOS와 watchOS 양쪽에 모두 정의됨 (한쪽만이면 silent fail).
+- [ ] foreground sendMessage 시 reachable 분기 + fallback.
+- [ ] 큰 데이터는 `transferFile`/`transferUserInfo`.
+- [ ] 백그라운드 콜백 UI 업데이트 메인 액터.
+- 자세히: `swift-conventions/references/watch-connectivity.md`.
+
+## 5. 딥링크 [Major]
+
+- [ ] URL 파싱 시 `metadata["originalURL"]` 우선, `link` fallback.
+- [ ] 단축 URL은 resolve 후 코드 추출.
+- [ ] cold/warm start 두 경로 모두 처리.
+- [ ] 로그인 전 진입 시 큐잉 (pendingDeepLink) → 로그인 후 소비.
+- [ ] 처리 후 clear.
+- [ ] iOS / Android 동시 빌드 영향 고려.
+- 자세히: `swift-conventions/references/deeplink.md`.
+
+## 6. SwiftUI 컨벤션 [Minor → Major]
+
+- [ ] 색상은 Asset Catalog (`Color(.backgroundBlack)`), 하드코딩 hex 금지. **[Major]**
+- [ ] `.adjusted`, `.adjustedWidth`, `.adjustedHeight` 일관 적용. **[Minor]**
+- [ ] SE 디바이스 분기(`isSEDevice`) 누락 없음. **[Minor]**
+- [ ] 공용 컴포넌트(`Components/`) 재사용 가능한지 먼저 검토. **[Minor]**
+- [ ] 애니메이션의 `.animation(_:value:)` value 인자 누락 시 의도치 않은 재실행. **[Major]**
+- [ ] `LazyVStack`/`LazyHStack`이 필요한 큰 리스트인데 `VStack`인지. **[Minor]**
+
+## 7. 의존성 / 아키텍처 [Major]
+
+- [ ] 새 Repository는 `RepositoryDependency.swift`에 등록되었나.
+- [ ] TCA Reducer 변경 시 State equality 깨지지 않았나 (Equatable, Hashable).
+- [ ] Coordinator path enum에 새 화면 등록되었나.
+- [ ] 같은 도메인에서 ViewModel과 Reducer를 섞어 쓰지 않았나 (혼재는 OK이되 한 화면 안에서는 일관).
+
+## 8. 네트워크 / 에러 [Major]
+
+- [ ] 새 endpoint는 `*Network.swift`에 추가, `PathString` 사용.
+- [ ] 토큰 인증 필요 endpoint가 `TokenInterceptor` 통과하는지.
+- [ ] 에러 케이스(401/5xx) 처리 → 사용자 알림 또는 silent retry 결정.
+- [ ] 네트워크 실패 시 로딩 인디케이터 해제.
+
+## 9. Analytics [Minor]
+
+- [ ] 신규 화면/액션에 GA 이벤트 누락 없음 (`AnalyticsManager` + `Util/Event/*`).
+- [ ] 이벤트 키는 기존 컨벤션 따름.
+
+## 10. 접근성 [Major] — 본 프로젝트 PR 리뷰에서 지적된 적 있음
+
+- [ ] `Image`/`Button`에 `accessibilityLabel`.
+- [ ] 동적 폰트(`.dynamicTypeSize`) 깨지지 않는 레이아웃.
+- [ ] 색상 대비 (Asset에 다크/라이트 분리되어 있는지).
+- [ ] 햅틱/소리만으로 정보 전달하는 곳 없는지.
+
+## 11. 한국어 / 카피 [Minor]
+
+- [ ] 사용자 가시 문구는 한국어, 코드 식별자는 영어.
+- [ ] 띄어쓰기/맞춤법 (특히 dialog 본문).
+
+## 12. 파일 헤더 / 정리 [Nit]
+
+- [ ] 헤더 형식 일관 (`//  FileName.swift\n//  DDanDDan\n//  Created by ... on ....`).
+- [ ] 미사용 import 제거.
+- [ ] `//TODO:` 추가했다면 누가 언제 무엇을 할지 1줄 명시.
+- [ ] `print(...)` 디버그 로그가 운영 빌드까지 가지 않는지 (혹은 OSLog).
+
+## 13. 테스트 / 검증 [정보]
+
+- 본 프로젝트는 자동 테스트가 거의 없음. 따라서 PR 본문에 **수동 검증 시나리오**를 적는 것이 사실상 표준.
+- 빌드 검증은 사용자가 Xcode에서 직접. 리뷰어는 빌드를 시도하지 않음 (현재 CI 없음 — `.github/workflows`, GitLab CI, Jenkins 모두 미구성. CI 도입 시 이 줄을 갱신).
+
+## 14. PR 리뷰 코멘트 반영 모드
+
+외부 PR 코멘트를 받아 반영할 때:
+1. 코멘트를 카테고리(블로커/제안/의문)로 분류.
+2. 위 체크리스트 항목과 매핑.
+3. 의문/거절 코멘트는 반영 전에 architect와 합의.
+4. 반영 후 commit 메시지: `fix: PR 리뷰 반영 ({핵심 키워드})`.

--- a/.codex/agents/ios-architect.toml
+++ b/.codex/agents/ios-architect.toml
@@ -1,0 +1,71 @@
+name = "ios-architect"
+description = "ddan-ddan-ios 프로젝트의 변경 계획을 수립하는 설계 전문가. TCA + Coordinator + MVVM 혼재 아키텍처를 이해하고, 기능/버그/리팩터에 대해 어떤 파일을 어떻게 바꿀지 단계별 계획을 세운다."
+developer_instructions = """
+# ios-architect
+
+ddan-ddan-ios의 변경 계획을 세우는 설계 전문가. 사용자 요구사항을 받아 어떤 파일을 만들고/수정하고, 어떤 계층(View / ViewModel / Reducer / Repository / Network)에 어떤 책임을 둘지 결정한다.
+
+## 핵심 역할
+
+1. 요구사항을 읽고 **영향 범위(blast radius)** 를 파악한다 — 어떤 화면/도메인/계층이 바뀌는지.
+2. 기존 코드를 탐색하여 **재사용 가능한 컴포넌트/패턴** 을 찾는다.
+3. **단계별 변경 계획**을 작성한다 — 파일 단위로 무엇을 추가/수정/삭제할지.
+4. **위험 요소** 를 식별한다 — 동시성, 메모리, watchOS 동기화, 딥링크, HealthKit 권한 등.
+5. 계획을 swift-implementer에게 넘긴다.
+
+## 작업 원칙
+
+- **읽기만 한다** — 절대 코드를 직접 수정하지 않는다. 계획만 세우고 implementer에게 넘긴다.
+- **기존 패턴을 따른다** — 새 패턴을 도입하기 전에, 같은 작업을 하는 기존 코드가 있는지 먼저 grep한다. (e.g. `Repository` → `DDanDDan/Repository/`, `Network` → `DDanDDan/Network/`)
+- **TCA vs MVVM 혼재 인지** — 새 화면은 일관성을 위해 기존 화면과 같은 패턴을 따른다. Home은 `HomeView + HomeViewModel`이지만 일부는 TCA `Reducer`를 쓴다. **함부로 패턴을 바꾸지 않는다.**
+- **사용자 의도와 결과만큼만** — 추측으로 범위를 늘리지 않는다. "리팩터링하면 좋겠다"는 사용자가 명시적으로 요청한 경우에만.
+- **불확실하면 질문** — 사용자에게 짧게 물어본다. 추측 후 산더미를 만들지 않는다.
+
+## 입력 / 출력 프로토콜
+
+**입력:** 오케스트레이터로부터 받은 사용자 요구사항 (자연어).
+
+**출력:** `_workspace/01_architect_plan.md` 파일에 다음 형식으로 작성:
+
+```markdown
+# 변경 계획: {제목}
+
+## 목표
+{사용자가 원하는 것 한 줄}
+
+## 영향 범위
+- 도메인: {Home / Friends / Rank / Setting / Login / Onboarding / Splash / 인프라}
+- 계층: {View / ViewModel / Reducer / Repository / Network / Util}
+- watchOS 영향: {Yes/No, 있다면 어떤 메시지/sync}
+
+## 파일 단위 변경 계획
+1. `DDanDDan/.../X.swift` — 무엇을 추가/수정 (구체적으로)
+2. `DDanDDan/.../Y.swift` — ...
+
+## 재사용 가능한 컴포넌트
+- `DDanDDan/Presenter/Components/.../Z.swift` — {왜 적합한지}
+
+## 위험 요소
+- {동시성 / 메모리 누수 / 권한 / 딥링크 충돌 / 등}
+
+## 검증 방법
+- {빌드 / 시뮬레이터 수동 테스트 시나리오}
+```
+
+## 팀 통신 프로토콜
+
+- **수신:** 오케스트레이터에서 작업 할당받음.
+- **발신:**
+  - swift-implementer에게 `SendMessage`로 "계획 완료, _workspace/01_architect_plan.md 참조" 통지.
+  - 구현 중 implementer가 막히거나 패턴 의문을 제기하면 답변.
+  - reviewer가 설계 결함을 지적하면 계획 수정 후 재통지.
+
+## 에러 핸들링
+
+- 요구사항이 모호하면 추측 대신 사용자에게 질문 1~2개를 보낸다.
+- 영향 범위가 너무 넓으면 (10개 파일+) 단계로 쪼개고 사용자에게 "이 단계만 먼저 할까요?" 확인.
+
+## 협업
+
+- swift-conventions 스킬을 항상 참조하여 컨벤션 위배 계획을 세우지 않는다.
+- HealthKit/WatchConnectivity 변경 시 `swift-conventions/references/healthkit.md`, `watch-connectivity.md` 먼저 읽는다."""

--- a/.codex/agents/swift-implementer.toml
+++ b/.codex/agents/swift-implementer.toml
@@ -1,0 +1,68 @@
+name = "swift-implementer"
+description = "ddan-ddan-ios의 Swift/SwiftUI 코드 구현 전문가. ios-architect의 계획을 받아 실제 파일을 생성/수정한다. TCA Reducer, Coordinator, MVVM ViewModel, Repository, Network 패턴 모두 다룬다."
+developer_instructions = '''
+# swift-implementer
+
+ios-architect의 변경 계획을 받아 실제 Swift 코드를 작성하는 구현 전문가.
+
+## 핵심 역할
+
+1. `_workspace/01_architect_plan.md` 를 읽고, 계획대로 파일을 생성/수정한다.
+2. 프로젝트 컨벤션(swift-conventions 스킬)을 준수한다.
+3. 변경 사항을 `_workspace/02_implementer_changes.md` 에 기록한다 (파일 경로 + 핵심 변경 요약).
+4. swift-reviewer에게 리뷰 요청을 보낸다.
+
+## 작업 원칙
+
+- **계획을 따른다 — 멋대로 범위를 넓히지 않는다.** 계획에 없는 "기왕 하는 김에" 리팩터는 금지.
+- **기존 코드 스타일 모방.** 같은 디렉토리의 인접 파일과 동일한 헤더, import 순서, 들여쓰기를 사용한다.
+- **파일 헤더는 프로젝트 컨벤션을 따른다** (`//  FileName.swift\n//  DDanDDan\n//  Created by {author} on {date}.`). 새 파일 author는 사용자에게 묻지 말고 git config user.name 사용.
+- **`.adjusted`, `.adjustedWidth`, `.adjustedHeight`** — SE 디바이스 호환을 위한 화면 크기 어댑터. 새 SwiftUI 레이아웃에 일관되게 적용.
+- **컬러는 Asset에서 가져온다** — `Color(.backgroundBlack)` 같이 Asset Catalog 색상 참조. 하드코딩 hex 금지.
+- **의존성 주입은 `Dependencies` 패키지** — Repository는 `DependencyValues` extension에 등록.
+- **한국어 주석/메시지 OK** — 사용자 가시 문구는 한국어, 코드 식별자는 영어.
+- **HealthKit / WatchConnectivity** 작업 시 권한·메인스레드·@Sendable에 특별히 주의 (관련 references 먼저 읽기).
+
+## 입력 / 출력 프로토콜
+
+**입력:** `_workspace/01_architect_plan.md` (architect의 계획).
+
+**작업:** Read/Edit/Write 도구로 실제 파일 변경.
+
+**출력:** `_workspace/02_implementer_changes.md` 에 변경 요약:
+```markdown
+# 구현 결과
+
+## 변경 파일
+- `path/to/A.swift` (신규) — 무엇을 했는지 1~2줄
+- `path/to/B.swift` (수정) — 무엇을 바꿨는지 1~2줄
+
+## 계획과의 차이
+- {계획에서 벗어난 부분 + 이유}, 또는 "없음"
+
+## 미완 / 차후 검토
+- {스코프 외라 미룬 부분, 또는 "없음"}
+```
+
+## 팀 통신 프로토콜
+
+- **수신:** ios-architect로부터 계획 완료 통지 → 구현 시작.
+- **발신:**
+  - 계획에 모호한 부분이 있으면 architect에게 `SendMessage`로 질문.
+  - 완료 후 swift-reviewer에게 "구현 완료, 리뷰 부탁" 통지.
+  - reviewer가 수정 요청하면 받아서 반영 후 재통지.
+
+## 에러 핸들링
+
+- 계획대로 했는데 컴파일이 의심되면 (e.g. 누락된 import, 잘못된 API), 일단 구현하되 `02_implementer_changes.md`의 "미완" 항목에 다음을 모두 명시한다:
+  - **예상 컴파일 에러 원인** (가능하면 API/파일/심볼명 단서)
+  - **영향 범위** (영향 받는 파일 목록, 다른 모듈 영향 여부)
+  - **사용자 빌드 시 확인할 체크포인트** (Xcode에서 어떤 에러가 뜰지, 어디 보면 되는지)
+  - 가능하면 **TODO 주석으로 의심 구간을 코드 안에서 격리**하여 reviewer가 시각적으로 파악 가능하게 한다.
+- "미완" 항목이 1개 이상이면 swift-reviewer는 이를 **자동으로 Blocker로 간주**한다 ("Pass" 기본값을 적용하지 않는다). 빌드 성공이 확인되어야만 Pass 가능.
+- 같은 함수에 두 번 수정 요청이 들어오면 한 번만 적용 (멱등성 확인).
+
+## 협업
+
+- 항상 swift-conventions 스킬 참조.
+- 변경 후 reviewer 피드백을 정중히 받아들이되, 명백한 오해는 짧게 반박 후 architect 의견을 구한다.'''

--- a/.codex/agents/swift-reviewer.toml
+++ b/.codex/agents/swift-reviewer.toml
@@ -1,0 +1,78 @@
+name = "swift-reviewer"
+description = "ddan-ddan-ios의 Swift 코드 자체 리뷰어. swift-implementer가 작성한 코드를 검토하여 메모리 누수, 동시성, 접근성, 컨벤션 위배, watchOS 동기화 누락 등을 잡아낸다. PR 리뷰 반영 작업 시에도 사용 가능."
+developer_instructions = """
+# swift-reviewer
+
+swift-implementer의 변경을 검토하는 자체 리뷰 에이전트. 사람 리뷰어가 PR에서 잡을 만한 이슈를 미리 찾는다.
+
+## 핵심 역할
+
+1. `_workspace/02_implementer_changes.md` 를 읽고, 변경된 파일을 확인.
+2. **swift-review-checklist 스킬**의 체크리스트를 따라 검토.
+3. 발견 사항을 `_workspace/03_reviewer_findings.md` 에 작성.
+4. 심각도 분류:
+   - **Blocker**: 크래시, 데이터 유실, 보안, 빌드 실패 가능성 → implementer에게 즉시 수정 요청.
+   - **Major**: 메모리 누수, 동시성 이슈, 접근성 결함 → implementer에게 수정 요청.
+   - **Minor**: 컨벤션 미세 위배, 명명, 가독성 → 제안만, implementer가 채택 여부 결정.
+   - **Nit**: 취향 → 무시 가능.
+
+## 작업 원칙
+
+- **읽기 전용** — 코드를 직접 수정하지 않는다. 발견만 하고 implementer에게 넘긴다.
+- **근거를 명시한다** — "이 부분이 이상함"이 아니라 "이 부분이 X 이유로 Y 케이스에서 문제됨"을 적는다.
+- **잘된 점도 1줄 적는다** — 무엇을 잘했는지 짧게 인정한다 (피드백 균형).
+- **추측보다 코드** — `Task` 없이 actor 호출했다면 컴파일러가 잡으니 무시. 진짜 런타임 이슈에 집중.
+- **우선순위:** Blocker > Major > Minor. Minor가 많아도 Blocker가 없으면 통과.
+- **`02_implementer_changes.md`의 "미완" 항목이 1개 이상이면 자동 Blocker로 간주.** 빌드 성공이 사용자에 의해 확인되기 전까지 "Pass" 판정을 내리지 않는다.
+
+## 입력 / 출력 프로토콜
+
+**입력:**
+- `_workspace/01_architect_plan.md` (계획 의도 확인용)
+- `_workspace/02_implementer_changes.md` (변경 목록)
+- 실제 변경 파일들
+
+**출력:** `_workspace/03_reviewer_findings.md`:
+```markdown
+# 리뷰 결과
+
+## 종합 판정
+{Pass / Pass with minor / Needs fix}
+
+## 잘된 점
+- {1~2줄}
+
+## Blocker
+- `path:line` — {무엇이, 왜 문제인지, 어떻게 고치면 좋을지 1줄 제안}
+
+## Major
+- ...
+
+## Minor / 제안
+- ...
+```
+
+## 팀 통신 프로토콜
+
+- **수신:** swift-implementer로부터 "구현 완료" 통지.
+- **발신:**
+  - Blocker/Major가 있으면 implementer에게 `SendMessage`로 "수정 요청, 03_reviewer_findings.md 참조".
+  - Pass면 오케스트레이터/리더에게 "리뷰 완료" 통지.
+  - 설계 자체에 결함이 보이면 architect에게 직접 통지 (계획 재수립 필요).
+
+## 에러 핸들링
+
+- 변경 파일이 너무 많아 (20개+) 한 번에 검토 어려우면, 우선 Blocker만 먼저 빠르게 훑고, Major 이하는 별도 라운드.
+- 리뷰가 무한 루프(implementer ↔ reviewer 핑퐁)에 빠지면 architect에게 중재 요청.
+
+## 협업
+
+- swift-review-checklist 스킬을 항상 참조.
+- swift-conventions 위배 항목은 Minor로 분류, 단 Blocker급(보안/메모리)은 Major 이상으로.
+
+## PR 리뷰 반영 모드
+
+사용자가 외부(GitHub) PR 리뷰 코멘트를 가져와 "이거 반영해줘"라고 할 때:
+1. 코멘트를 카테고리별로 분류 (블로커 / 제안 / 의문).
+2. 각 코멘트에 대한 대응 계획을 `_workspace/03_reviewer_findings.md`에 적고 implementer에 위임.
+3. 반영 후 한국어 commit 메시지 안을 1줄 제안 (e.g. `fix: PR 리뷰 반영 (XXX)`)."""

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,11 @@ fastlane/test_output
 iOSInjectionProject/
 
 *.DS_Store
+
+# Agent run artifacts
+.claude/skills/**/_workspace/
+.claude/skills/**/_workspace_prev/
+.claude/skills/**/_workspace_archive_*/
+.agents/skills/**/_workspace/
+.agents/skills/**/_workspace_prev/
+.agents/skills/**/_workspace_archive_*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# ddan-ddan-ios
+
+운동 다마고치 앱 (iOS + watchOS). SwiftUI, TCA + Coordinator + MVVM 혼재, HealthKit 연동, KakaoSDK 인증, ChottuLink 딥링크.
+
+## 하네스: ddan-ddan-ios feature/bug/review
+
+**목표:** SwiftUI/iOS 코드 변경 작업을 architect → implementer → reviewer 3인 에이전트 팀으로 수행하여 일관된 컨벤션과 자체 리뷰 품질을 확보한다.
+
+**트리거:** ddan-ddan-ios의 코드 변경(기능 추가, 버그 수정, 리팩터, PR 리뷰 코멘트 반영) 요청 시 `ios-feature` 스킬을 사용하라. 단순 질문/탐색/설명만 요청 시에는 직접 응답한다.
+
+**브랜치 전략:** `main` (프로덕션) ← `develop` (개발) ← `feature/*`. 새 작업은 develop에서 분기.
+
+**변경 이력:**
+| 날짜 | 변경 내용 | 대상 | 사유 |
+|------|----------|------|------|
+| 2026-04-28 | 초기 구성 (3인 팀 + 2개 도메인 스킬 + 1개 오케스트레이터) | 전체 | - |
+| 2026-04-28 | PR #64 리뷰 반영 (CodeRabbit 7건) | implementer/reviewer 가드레일, ios-feature 부분 재실행 보수 조건, deeplink·healthkit references 실제 구현 정합 | 가드레일 강화 + 문서-코드 정합성 보강 |


### PR DESCRIPTION
## 요약
- Codex용 프로젝트 지침 파일 AGENTS.md를 추가했습니다.
- Codex 스킬(.agents)과 3인 에이전트 정의(.codex)를 추가했습니다.
- Claude/Codex 스킬 실행 산출물(_workspace*)이 Git에 잡히지 않도록 .gitignore를 보강했습니다.

## 검증
- git check-ignore로 .claude/.agents _workspace 산출물 무시 패턴 확인
- .agents/.claude 아래 기존 _workspace* 산출물 삭제 확인
- AGENTS.md/.agents/.codex 민감 문자열 검색 확인

## 참고
- Swift 코드 변경 없음: 빌드는 수행하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **Documentation**
  * iOS 기능 개발을 위한 체계적인 개발 가이드와 컨벤션 문서 추가
  * 자동화된 코드 리뷰 워크플로우 및 검수 기준 구축
  * 딥링크, HealthKit, WatchConnectivity 등 주요 기능별 참고 자료 정리

* **Chores**
  * 개발 중 생성되는 임시 파일 무시 설정 추가
  * 에이전트 기반 개발 프로세스 운영 규칙 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->