### PR TITLE
feat: 문의하기 Tally 링크에 userId 전달

### DIFF
--- a/DDanDDan/Presenter/Setting/SettingView.swift
+++ b/DDanDDan/Presenter/Setting/SettingView.swift
@@ -248,16 +248,23 @@ extension SettingView {
                 AnalyticsManager.shared.logEvent(event: SettingEvent.clickDeleteAccount())
                 coordinator.push(to: item)
             case .inquiry:
-                if let url = URL(string: "https://tally.so/r/Gx1GEe") {
+                if let url = inquiryURL {
                     UIApplication.shared.open(url)
                 }
             default:
                 coordinator.push(to: item)
             }
         }
+
+        private var inquiryURL: URL? {
+            var components = URLComponents(string: "https://tally.so/r/Gx1GEe")
+            components?.queryItems = [
+                URLQueryItem(name: "userId", value: UserDefaultValue.userId)
+            ]
+            return components?.url
+        }
     }
 }
 #Preview {
     SettingView(coordinator: AppCoordinator(), store: Store(initialState: SettingViewReducer.State(), reducer: { SettingViewReducer(repository: SettingRepository()) }))
 }
-

--- a/DDanDDan/Util/UserManager.swift
+++ b/DDanDDan/Util/UserManager.swift
@@ -56,6 +56,7 @@ actor UserManager: ObservableObject {
             accessToken = nil
             UserDefaultValue.accessToken = nil
             UserDefaultValue.refreshToken = nil
+            UserDefaultValue.userId = ""
             coordinator?.setRoot(to: .login)
         }
     }


### PR DESCRIPTION
## 작업 내용
- 설정 > 문의하기에서 Tally 링크를 열 때 `userId` 쿼리 파라미터를 함께 전달하도록 수정했습니다.
- `UserDefaultValue.userId`에 저장된 서버 유저 ObjectId를 `URLQueryItem(name: "userId", value: ...)`로 붙이도록 했습니다.
- URL 문자열 직접 결합 대신 `URLComponents`를 사용했습니다.
- 로그아웃 시 `UserDefaultValue.userId`를 빈 문자열로 초기화해 이전 계정 식별자가 남지 않도록 했습니다.

## 검증
- XcodeBuildMCP `build_sim` 성공
  - Scheme: `DDanDDan`
  - Simulator: `iPhone 17 Pro`
  - Configuration: `Debug`
- CodeRabbit 최신 커밋 리뷰 승인

## 확인 필요
- Tally 폼에 hidden field 이름이 `userId`로 설정되어 있어야 제출 데이터에 함께 저장됩니다.
