### PR TITLE
feat: 문의하기에 디바이스 정보 전달

### DIFF
--- a/DDanDDan/Presenter/Setting/SettingView.swift
+++ b/DDanDDan/Presenter/Setting/SettingView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 import ComposableArchitecture
 
 enum SettingPath: Hashable, CaseIterable {
@@ -259,9 +260,33 @@ extension SettingView {
         private var inquiryURL: URL? {
             var components = URLComponents(string: "https://tally.so/r/Gx1GEe")
             components?.queryItems = [
-                URLQueryItem(name: "userId", value: UserDefaultValue.userId)
+                URLQueryItem(name: "userId", value: UserDefaultValue.userId),
+                URLQueryItem(name: "deviceModel", value: deviceModel),
+                URLQueryItem(name: "osVersion", value: UIDevice.current.systemVersion),
+                URLQueryItem(name: "appVersion", value: appVersion)
             ]
             return components?.url
+        }
+
+        private var deviceModel: String {
+            #if targetEnvironment(simulator)
+            return ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"]
+                ?? UIDevice.current.model
+            #else
+            var systemInfo = utsname()
+            uname(&systemInfo)
+
+            return withUnsafePointer(to: &systemInfo.machine) {
+                $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                    String(cString: $0)
+                }
+            }
+            #endif
+        }
+
+        private var appVersion: String {
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+                ?? "unknown"
         }
     }
 }


### PR DESCRIPTION
## 작업 내용
- 기존 Tally 문의 링크의 `userId`에 아래 디바이스 정보를 추가로 전달합니다.
  - `deviceModel`: 하드웨어 모델 식별자 (예: `iPhone16,1`)
  - `osVersion`: 현재 iOS 버전
  - `appVersion`: 현재 앱 버전
- 시뮬레이터에서는 `SIMULATOR_MODEL_IDENTIFIER`를 사용합니다.
- `URLComponents`와 `URLQueryItem`을 유지해 각 값을 안전하게 인코딩합니다.

## 검증
- XcodeBuildMCP `build_sim` 성공
  - Scheme: `DDanDDan`
  - Simulator: `iPhone 17 Pro`
  - Configuration: `Debug`

## 확인 필요
- Tally 폼에 `deviceModel`, `osVersion`, `appVersion` hidden field를 동일한 이름으로 추가해야 제출 데이터에 저장됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 문의 링크에 기기 정보와 앱 버전이 함께 전달되도록 개선되어, 지원 요청 시 더 정확한 정보가 포함됩니다.
  * 시뮬레이터와 실제 기기에서 기기 식별 정보가 안정적으로 반영되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->