### PR TITLE
feat: 서버 기반 펫 카탈로그 및 리비전 동기화

### DIFF
--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0CD4DC0635E949E8BE598F2C /* bg_diamond_sm.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8596780C2BD446B684A40536 /* bg_diamond_sm.svg */; };
+		242C2A240FB540AB94305D76 /* bg_diamond.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9AA318A13D254D0687720811 /* bg_diamond.svg */; };
+		2DF8EAA557AEE22DC06BFDE5 /* PetCatalogResponseHeaderHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A543F461AFC15F8A86202158 /* PetCatalogResponseHeaderHandler.swift */; };
+		2EB72FA291F7851BBF3551DD /* PetCatalogRevisionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBF5FD50647EC7DEDF12735 /* PetCatalogRevisionStore.swift */; };
 		36022B732CCAA04000D360C0 /* HomeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36022B722CCAA04000D360C0 /* HomeButton.swift */; };
 		360E6B362CEBC5F10059661E /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 360E6B352CEBC5F10059661E /* SplashView.swift */; };
 		360E6B382CEBC8A60059661E /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 360E6B372CEBC8A60059661E /* SplashViewModel.swift */; };
@@ -153,9 +157,21 @@
 		36F6E8212CEE7DE000B395FB /* CheckButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E8202CEE7DE000B395FB /* CheckButton.swift */; };
 		36F6E8232CEE8F0B00B395FB /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F6E8222CEE8F0B00B395FB /* String+.swift */; };
 		5416D1439ADD5D43B7518D46 /* PetCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFABC97C4956364FC9830AC /* PetCatalog.swift */; };
-		A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430817BD29DFEF1965C8A57F /* PetAssetCache.swift */; };
+		5611644501A7994E9ABEF298 /* PetCatalogHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1D1C98CAF4C71E34D12467 /* PetCatalogHeaderTests.swift */; };
+		6CAD2C19AE344102A23FF6A3 /* PetBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B691428496948CFB3C6A561 /* PetBackground.swift */; };
+		823F8ECC33DE2F4EA687302C /* PetCatalogHeaderInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3C3C0A0789D2EC407DD86F /* PetCatalogHeaderInterceptor.swift */; };
 		8A61ABEB15F9B0685191A463 /* PetArchiveCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3220B828426F2AA2D4C028 /* PetArchiveCache.swift */; };
+		96DBE4ECA76ACD5D9201ECEE /* PetCatalogRefreshCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13432D3973B87661C05BE299 /* PetCatalogRefreshCoordinator.swift */; };
+		9A063619CE5F4C96AB0C83F6 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */; };
+		9CCC0517601A468ABC0343AD /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */; };
+		A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430817BD29DFEF1965C8A57F /* PetAssetCache.swift */; };
+		BA0FAB047C174168AC46DFE3 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */; };
+		C0D3A0010000000000000001 /* PetCatalogRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3A0020000000000000002 /* PetCatalogRepository.swift */; };
+		C0D3A0030000000000000003 /* PetCatalogStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3A0040000000000000004 /* PetCatalogStorage.swift */; };
+		C0D3A0050000000000000005 /* RemotePetAssetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3A0060000000000000006 /* RemotePetAssetView.swift */; };
+		C0D4A0010000000000000001 /* PetCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D4A0020000000000000002 /* PetCatalogTests.swift */; };
 		C9D8EED051CEED09043E7CC9 /* PetCatalogNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */; };
+		E6B6489FCE4A418AA1B22DB0 /* bg_rectangle.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2124975870F342A3B3984E72 /* bg_rectangle.svg */; };
 		F809E2FA2CBD05F5001BE099 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2F92CBD05F5001BE099 /* UserData.swift */; };
 		F809E2FC2CBD06A1001BE099 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2FB2CBD06A1001BE099 /* UserManager.swift */; };
 		F809E2FE2CBD0841001BE099 /* DeleteUserConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F809E2FD2CBD0841001BE099 /* DeleteUserConfirmView.swift */; };
@@ -212,13 +228,6 @@
 		F9BCC0AF2E8227B60035E1AF /* FriendCardRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BCC0AE2E8227AC0035E1AF /* FriendCardRepository.swift */; };
 		F9BCC0E32E8274640035E1AF /* RepositoryDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BCC0E22E82745B0035E1AF /* RepositoryDependency.swift */; };
 		F9C3DE8A2E7142B400DE5E4C /* FriendCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C3DE892E7142AC00DE5E4C /* FriendCardView.swift */; };
-		6CAD2C19AE344102A23FF6A3 /* PetBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B691428496948CFB3C6A561 /* PetBackground.swift */; };
-		BA0FAB047C174168AC46DFE3 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */; };
-		9CCC0517601A468ABC0343AD /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */; };
-		9A063619CE5F4C96AB0C83F6 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */; };
-		242C2A240FB540AB94305D76 /* bg_diamond.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9AA318A13D254D0687720811 /* bg_diamond.svg */; };
-		0CD4DC0635E949E8BE598F2C /* bg_diamond_sm.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8596780C2BD446B684A40536 /* bg_diamond_sm.svg */; };
-		E6B6489FCE4A418AA1B22DB0 /* bg_rectangle.svg in Resources */ = {isa = PBXBuildFile; fileRef = 2124975870F342A3B3984E72 /* bg_rectangle.svg */; };
 		F9CCAF422DB22B4300549DAE /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = F9CCAF412DB22B4300549DAE /* FirebaseCrashlytics */; };
 		F9E4217A2D0ED657005A5795 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = F9E421792D0ED657005A5795 /* ComposableArchitecture */; };
 		F9F56EDD2D9B6E7C0085E266 /* NetworkEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F56EDC2D9B6E7C0085E266 /* NetworkEvent.swift */; };
@@ -267,6 +276,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 36E0196B2CCA830A00383318;
 			remoteInfo = "DdanDdan_Watch Watch App";
+		};
+		C0D4A0030000000000000003 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8AB33222C2EAD2E00BC16C9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8AB33292C2EAD2E00BC16C9;
+			remoteInfo = DDanDDan;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -319,6 +335,10 @@
 
 /* Begin PBXFileReference section */
 		0CFABC97C4956364FC9830AC /* PetCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalog.swift; sourceTree = "<group>"; };
+		13432D3973B87661C05BE299 /* PetCatalogRefreshCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogRefreshCoordinator.swift; sourceTree = "<group>"; };
+		1BBF5FD50647EC7DEDF12735 /* PetCatalogRevisionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogRevisionStore.swift; sourceTree = "<group>"; };
+		2124975870F342A3B3984E72 /* bg_rectangle.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = bg_rectangle.svg; sourceTree = "<group>"; };
+		2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		36022B722CCAA04000D360C0 /* HomeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeButton.swift; sourceTree = "<group>"; };
 		360E6B352CEBC5F10059661E /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		360E6B372CEBC8A60059661E /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
@@ -457,7 +477,17 @@
 		36F6E8202CEE7DE000B395FB /* CheckButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckButton.swift; sourceTree = "<group>"; };
 		36F6E8222CEE8F0B00B395FB /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		430817BD29DFEF1965C8A57F /* PetAssetCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetAssetCache.swift; sourceTree = "<group>"; };
+		4E3C3C0A0789D2EC407DD86F /* PetCatalogHeaderInterceptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogHeaderInterceptor.swift; sourceTree = "<group>"; };
+		6B691428496948CFB3C6A561 /* PetBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetBackground.swift; sourceTree = "<group>"; };
+		8596780C2BD446B684A40536 /* bg_diamond_sm.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = bg_diamond_sm.svg; sourceTree = "<group>"; };
+		9AA318A13D254D0687720811 /* bg_diamond.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = bg_diamond.svg; sourceTree = "<group>"; };
+		A543F461AFC15F8A86202158 /* PetCatalogResponseHeaderHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogResponseHeaderHandler.swift; sourceTree = "<group>"; };
 		AD3220B828426F2AA2D4C028 /* PetArchiveCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetArchiveCache.swift; sourceTree = "<group>"; };
+		C0D3A0020000000000000002 /* PetCatalogRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetCatalogRepository.swift; sourceTree = "<group>"; };
+		C0D3A0040000000000000004 /* PetCatalogStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetCatalogStorage.swift; sourceTree = "<group>"; };
+		C0D3A0060000000000000006 /* RemotePetAssetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePetAssetView.swift; sourceTree = "<group>"; };
+		C0D4A0020000000000000002 /* PetCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetCatalogTests.swift; sourceTree = "<group>"; };
+		C0D4A0040000000000000004 /* DDanDDanTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DDanDDanTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogNetwork.swift; sourceTree = "<group>"; };
 		F809E2F92CBD05F5001BE099 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		F809E2FB2CBD06A1001BE099 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
@@ -511,13 +541,9 @@
 		F9BCC0AE2E8227AC0035E1AF /* FriendCardRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCardRepository.swift; sourceTree = "<group>"; };
 		F9BCC0E22E82745B0035E1AF /* RepositoryDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDependency.swift; sourceTree = "<group>"; };
 		F9C3DE892E7142AC00DE5E4C /* FriendCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCardView.swift; sourceTree = "<group>"; };
-		6B691428496948CFB3C6A561 /* PetBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetBackground.swift; sourceTree = "<group>"; };
-		2CE74FCD6BD048ECA04BCC44 /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
-		9AA318A13D254D0687720811 /* bg_diamond.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = bg_diamond.svg; sourceTree = "<group>"; };
-		8596780C2BD446B684A40536 /* bg_diamond_sm.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = bg_diamond_sm.svg; sourceTree = "<group>"; };
-		2124975870F342A3B3984E72 /* bg_rectangle.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = bg_rectangle.svg; sourceTree = "<group>"; };
 		F9F56EDC2D9B6E7C0085E266 /* NetworkEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEvent.swift; sourceTree = "<group>"; };
 		F9F6B17B2D7AEA8500FA6F34 /* SettingViewReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewReducer.swift; sourceTree = "<group>"; };
+		FD1D1C98CAF4C71E34D12467 /* PetCatalogHeaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetCatalogHeaderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -604,6 +630,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0D4A0050000000000000005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8AB33272C2EAD2E00BC16C9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -644,16 +677,6 @@
 				36448A882D1AAFEB005CFC8C /* WatchFont.swift */,
 			);
 			path = Resource;
-			sourceTree = "<group>";
-		};
-		C86EE08639BC42C1993CCB11 /* Background */ = {
-			isa = PBXGroup;
-			children = (
-				9AA318A13D254D0687720811 /* bg_diamond.svg */,
-				8596780C2BD446B684A40536 /* bg_diamond_sm.svg */,
-				2124975870F342A3B3984E72 /* bg_rectangle.svg */,
-			);
-			path = Background;
 			sourceTree = "<group>";
 		};
 		362864912C89BFA700029452 /* Fonts */ = {
@@ -804,6 +827,7 @@
 		367A79712CDD08C90055771B /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				C0D3A0020000000000000002 /* PetCatalogRepository.swift */,
 				F9BCC0B02E82297A0035E1AF /* Dependencies */,
 				F88FC6E22CCF6C6A0033D4C9 /* SettingRepository.swift */,
 				F88663D92CC8F952008DB860 /* LoginRepository.swift */,
@@ -812,6 +836,7 @@
 				369F16F42D8707E50039ED3A /* RankRepository.swift */,
 				36BC7D062E82EA7D002B1ED5 /* FriendRepository.swift */,
 				F9BCC0AE2E8227AC0035E1AF /* FriendCardRepository.swift */,
+				13432D3973B87661C05BE299 /* PetCatalogRefreshCoordinator.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -941,6 +966,25 @@
 			path = Splash;
 			sourceTree = "<group>";
 		};
+		C0D4A0060000000000000006 /* DDanDDanTests */ = {
+			isa = PBXGroup;
+			children = (
+				C0D4A0020000000000000002 /* PetCatalogTests.swift */,
+				FD1D1C98CAF4C71E34D12467 /* PetCatalogHeaderTests.swift */,
+			);
+			path = DDanDDanTests;
+			sourceTree = "<group>";
+		};
+		C86EE08639BC42C1993CCB11 /* Background */ = {
+			isa = PBXGroup;
+			children = (
+				9AA318A13D254D0687720811 /* bg_diamond.svg */,
+				8596780C2BD446B684A40536 /* bg_diamond_sm.svg */,
+				2124975870F342A3B3984E72 /* bg_rectangle.svg */,
+			);
+			path = Background;
+			sourceTree = "<group>";
+		};
 		F809E2F82CBD05E4001BE099 /* User */ = {
 			isa = PBXGroup;
 			children = (
@@ -970,6 +1014,7 @@
 		F8311F952C7060B3000455ED /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				C0D3A0060000000000000006 /* RemotePetAssetView.swift */,
 				F9C3DE8B2E7142B700DE5E4C /* FriendCard */,
 				369F16F12D7CC1280039ED3A /* CustomTabView.swift */,
 				369F16ED2D7CB4B40039ED3A /* TooltipView.swift */,
@@ -1070,6 +1115,8 @@
 				F9A845A92E862BD10021D0FE /* CheerNetwork.swift */,
 				36BC7D012E82E959002B1ED5 /* FriendNetwork.swift */,
 				EB19BFBC4C7C19017EC9D8F6 /* PetCatalogNetwork.swift */,
+				4E3C3C0A0789D2EC407DD86F /* PetCatalogHeaderInterceptor.swift */,
+				A543F461AFC15F8A86202158 /* PetCatalogResponseHeaderHandler.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1109,6 +1156,7 @@
 		F89A2EBA2C7C80AF00FE3A36 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				C0D3A0040000000000000004 /* PetCatalogStorage.swift */,
 				F9F56EDB2D9B6E710085E266 /* Event */,
 				367A79A92CDE07900055771B /* Extension */,
 				F8758CF02C8EDF6B0038CCBB /* HealthKitManager.swift */,
@@ -1120,6 +1168,7 @@
 				363CC4472CCADC6A00D2EE47 /* WatchConnectivityManager.swift */,
 				430817BD29DFEF1965C8A57F /* PetAssetCache.swift */,
 				AD3220B828426F2AA2D4C028 /* PetArchiveCache.swift */,
+				1BBF5FD50647EC7DEDF12735 /* PetCatalogRevisionStore.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1127,6 +1176,7 @@
 		F8AB33212C2EAD2E00BC16C9 = {
 			isa = PBXGroup;
 			children = (
+				C0D4A0060000000000000006 /* DDanDDanTests */,
 				36A9D72E2DED7CB700A9169A /* DDanDDan_WidgetExtension.entitlements */,
 				F98C35432D0C1FD300A1E6C5 /* Config.xcconfig */,
 				364195622D53A5E80065C400 /* GoogleService-Info.plist */,
@@ -1146,6 +1196,7 @@
 		F8AB332B2C2EAD2E00BC16C9 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				C0D4A0040000000000000004 /* DDanDDanTests.xctest */,
 				F8AB332A2C2EAD2E00BC16C9 /* DDanDDan.app */,
 				36E0196C2CCA830A00383318 /* DdanDdan_Watch Watch App.app */,
 				36E0197B2CCA830C00383318 /* DdanDdan_Watch Watch AppTests.xctest */,
@@ -1340,6 +1391,24 @@
 			productReference = 36E019852CCA830C00383318 /* DdanDdan_Watch Watch AppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		C0D4A00A000000000000000A /* DDanDDanTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0D4A00B000000000000000B /* Build configuration list for PBXNativeTarget "DDanDDanTests" */;
+			buildPhases = (
+				C0D4A0080000000000000008 /* Sources */,
+				C0D4A0050000000000000005 /* Frameworks */,
+				C0D4A0070000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C0D4A0090000000000000009 /* PBXTargetDependency */,
+			);
+			name = DDanDDanTests;
+			productName = DDanDDanTests;
+			productReference = C0D4A0040000000000000004 /* DDanDDanTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		F8AB33292C2EAD2E00BC16C9 /* DDanDDan */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8AB33382C2EAD2F00BC16C9 /* Build configuration list for PBXNativeTarget "DDanDDan" */;
@@ -1405,6 +1474,10 @@
 						CreatedOnToolsVersion = 16.0;
 						TestTargetID = 36E0196B2CCA830A00383318;
 					};
+					C0D4A00A000000000000000A = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = F8AB33292C2EAD2E00BC16C9;
+					};
 					F8AB33292C2EAD2E00BC16C9 = {
 						CreatedOnToolsVersion = 15.3;
 					};
@@ -1430,6 +1503,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				C0D4A00A000000000000000A /* DDanDDanTests */,
 				F8AB33292C2EAD2E00BC16C9 /* DDanDDan */,
 				36E0196B2CCA830A00383318 /* DdanDdan_Watch Watch App */,
 				36E0197A2CCA830C00383318 /* DdanDdan_Watch Watch AppTests */,
@@ -1475,6 +1549,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		36E019832CCA830C00383318 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C0D4A0070000000000000007 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1575,7 +1656,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+			shellScript = "CRASHLYTICS_RUN=\"${SOURCE_PACKAGES_DIR_PATH}/checkouts/firebase-ios-sdk/Crashlytics/run\"\nif [ ! -x \"${CRASHLYTICS_RUN}\" ]; then\n  CRASHLYTICS_RUN=\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nfi\nif [ -x \"${CRASHLYTICS_RUN}\" ]; then\n  \"${CRASHLYTICS_RUN}\"\nelse\n  echo \"warning: Crashlytics run script not found; skipping symbol upload\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1626,6 +1707,15 @@
 			files = (
 				3692E05D2CF00CBC0079D2B8 /* DdanDdan_Watch_Watch_AppUITests.swift in Sources */,
 				3692E05E2CF00CBC0079D2B8 /* DdanDdan_Watch_Watch_AppUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C0D4A0080000000000000008 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0D4A0010000000000000001 /* PetCatalogTests.swift in Sources */,
+				5611644501A7994E9ABEF298 /* PetCatalogHeaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1744,7 +1834,14 @@
 				5416D1439ADD5D43B7518D46 /* PetCatalog.swift in Sources */,
 				C9D8EED051CEED09043E7CC9 /* PetCatalogNetwork.swift in Sources */,
 				A3529FFED7C1CE5D42C40DD0 /* PetAssetCache.swift in Sources */,
+				C0D3A0010000000000000001 /* PetCatalogRepository.swift in Sources */,
+				C0D3A0030000000000000003 /* PetCatalogStorage.swift in Sources */,
+				C0D3A0050000000000000005 /* RemotePetAssetView.swift in Sources */,
 				8A61ABEB15F9B0685191A463 /* PetArchiveCache.swift in Sources */,
+				823F8ECC33DE2F4EA687302C /* PetCatalogHeaderInterceptor.swift in Sources */,
+				2DF8EAA557AEE22DC06BFDE5 /* PetCatalogResponseHeaderHandler.swift in Sources */,
+				96DBE4ECA76ACD5D9201ECEE /* PetCatalogRefreshCoordinator.swift in Sources */,
+				2EB72FA291F7851BBF3551DD /* PetCatalogRevisionStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1780,6 +1877,11 @@
 			isa = PBXTargetDependency;
 			target = 36E0196B2CCA830A00383318 /* DdanDdan_Watch Watch App */;
 			targetProxy = 36E0198D2CCA830C00383318 /* PBXContainerItemProxy */;
+		};
+		C0D4A0090000000000000009 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8AB33292C2EAD2E00BC16C9 /* DDanDDan */;
+			targetProxy = C0D4A0030000000000000003 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2082,6 +2184,40 @@
 			};
 			name = Release;
 		};
+		C0D4A00C000000000000000C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 65NSM7Z327;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = inc.ddanddan.DDanDDanTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DDanDDan.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DDanDDan";
+			};
+			name = Debug;
+		};
+		C0D4A00D000000000000000D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 65NSM7Z327;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = inc.ddanddan.DDanDDanTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DDanDDan.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DDanDDan";
+			};
+			name = Release;
+		};
 		F8AB33362C2EAD2F00BC16C9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 364195A12D6199D60065C400 /* Config_dev.xcconfig */;
@@ -2349,6 +2485,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C0D4A00B000000000000000B /* Build configuration list for PBXNativeTarget "DDanDDanTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0D4A00C000000000000000C /* Debug */,
+				C0D4A00D000000000000000D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F8AB33252C2EAD2E00BC16C9 /* Build configuration list for PBXProject "DDanDDan" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2370,6 +2515,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		091CA7D7629843AC8F8D1F95 /* XCRemoteSwiftPackageReference "SVGView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/exyte/SVGView";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.6;
+			};
+		};
 		3641954C2D4D18890065C400 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -2402,14 +2555,6 @@
 				minimumVersion = 1.26.0;
 			};
 		};
-		091CA7D7629843AC8F8D1F95 /* XCRemoteSwiftPackageReference "SVGView" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/exyte/SVGView";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.6;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2427,6 +2572,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 36465D732CF7F28100784E8A /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		82F74F22E0FE484382F1BCE7 /* SVGView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 091CA7D7629843AC8F8D1F95 /* XCRemoteSwiftPackageReference "SVGView" */;
+			productName = SVGView;
 		};
 		F8C10C0C2C5782720037D6A5 /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -2467,11 +2617,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F9E421782D0ED49C005A5795 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
 			productName = ComposableArchitecture;
-		};
-		82F74F22E0FE484382F1BCE7 /* SVGView */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 091CA7D7629843AC8F8D1F95 /* XCRemoteSwiftPackageReference "SVGView" */;
-			productName = SVGView;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A10F00010000000000000001 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A10F00030000000000000003 /* Alamofire */; };
+		A10F00020000000000000002 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A10F00040000000000000004 /* Alamofire */; };
 		0CD4DC0635E949E8BE598F2C /* bg_diamond_sm.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8596780C2BD446B684A40536 /* bg_diamond_sm.svg */; };
 		242C2A240FB540AB94305D76 /* bg_diamond.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9AA318A13D254D0687720811 /* bg_diamond.svg */; };
 		2DF8EAA557AEE22DC06BFDE5 /* PetCatalogResponseHeaderHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A543F461AFC15F8A86202158 /* PetCatalogResponseHeaderHandler.swift */; };
@@ -634,6 +636,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A10F00020000000000000002 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -641,6 +644,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A10F00010000000000000001 /* Alamofire in Frameworks */,
 				364195502D4D18890065C400 /* FirebaseMessaging in Frameworks */,
 				3641954E2D4D18890065C400 /* FirebaseAnalytics in Frameworks */,
 				36465D752CF7F28100784E8A /* Lottie in Frameworks */,
@@ -1405,6 +1409,9 @@
 				C0D4A0090000000000000009 /* PBXTargetDependency */,
 			);
 			name = DDanDDanTests;
+			packageProductDependencies = (
+				A10F00040000000000000004 /* Alamofire */,
+			);
 			productName = DDanDDanTests;
 			productReference = C0D4A0040000000000000004 /* DDanDDanTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -1430,6 +1437,7 @@
 			);
 			name = DDanDDan;
 			packageProductDependencies = (
+				A10F00030000000000000003 /* Alamofire */,
 				F8C10C0C2C5782720037D6A5 /* KakaoSDK */,
 				F8C10C0E2C5782720037D6A5 /* KakaoSDKAuth */,
 				F8C10C102C5782720037D6A5 /* KakaoSDKCommon */,
@@ -1493,6 +1501,7 @@
 			);
 			mainGroup = F8AB33212C2EAD2E00BC16C9;
 			packageReferences = (
+				A10F00050000000000000005 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				F8C10C0B2C5782720037D6A5 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				36465D732CF7F28100784E8A /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				F9E421782D0ED49C005A5795 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
@@ -2515,6 +2524,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		A10F00050000000000000005 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.1;
+			};
+		};
 		091CA7D7629843AC8F8D1F95 /* XCRemoteSwiftPackageReference "SVGView" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/exyte/SVGView";
@@ -2558,6 +2575,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		A10F00030000000000000003 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10F00050000000000000005 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		A10F00040000000000000004 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A10F00050000000000000005 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
 		3641954D2D4D18890065C400 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3641954C2D4D18890065C400 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/DDanDDan.xcodeproj/project.pbxproj
+++ b/DDanDDan.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A10F00100000000000000010 /* SVGView in Frameworks */ = {isa = PBXBuildFile; productRef = A10F00110000000000000011 /* SVGView */; };
 		A10F00010000000000000001 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A10F00030000000000000003 /* Alamofire */; };
 		A10F00020000000000000002 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A10F00040000000000000004 /* Alamofire */; };
 		0CD4DC0635E949E8BE598F2C /* bg_diamond_sm.svg in Resources */ = {isa = PBXBuildFile; fileRef = 8596780C2BD446B684A40536 /* bg_diamond_sm.svg */; };
@@ -615,6 +616,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A10F00100000000000000010 /* SVGView in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1355,6 +1357,9 @@
 				36A9D7422DED8D7500A9169A /* PBXTargetDependency */,
 			);
 			name = "DdanDdan_Watch Watch App";
+			packageProductDependencies = (
+				A10F00110000000000000011 /* SVGView */,
+			);
 			productName = "DdanDdan_Watch Watch App";
 			productReference = 36E0196C2CCA830A00383318 /* DdanDdan_Watch Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -2575,6 +2580,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		A10F00110000000000000011 /* SVGView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 091CA7D7629843AC8F8D1F95 /* XCRemoteSwiftPackageReference "SVGView" */;
+			productName = SVGView;
+		};
 		A10F00030000000000000003 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A10F00050000000000000005 /* XCRemoteSwiftPackageReference "Alamofire" */;

--- a/DDanDDan.xcodeproj/xcshareddata/xcschemes/DDanDDan.xcscheme
+++ b/DDanDDan.xcodeproj/xcshareddata/xcschemes/DDanDDan.xcscheme
@@ -28,7 +28,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldAutocreateTestPlan = "NO">
+      <Testables>
+         <TestableReference skipped = "NO" parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C0D4A00A000000000000000A"
+               BuildableName = "DDanDDanTests.xctest"
+               BlueprintName = "DDanDDanTests"
+               ReferencedContainer = "container:DDanDDan.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/DDanDDan/AppCoordinator.swift
+++ b/DDanDDan/AppCoordinator.swift
@@ -19,7 +19,7 @@ enum AppPath: Hashable {
 
 /// 메인 펫 변경 시 홈에 즉시 반영할 새 펫 정보.
 struct PetChangePayload: Equatable {
-    let petType: PetType
+    let petType: String
     let level: Int
     let expPercent: Double
 }
@@ -66,6 +66,16 @@ final class AppCoordinator: ObservableObject {
             navigationPath.removeLast(navigationPath.count)
             rootView = path
         }
+    }
+
+    /// 인증 bootstrap 결과를 한 MainActor transaction에서 반영한다.
+    /// Splash가 반환된 뒤에도 이전 root가 남는 비동기 전환 구간을 만들지 않는다.
+    @MainActor
+    func commitAuthenticatedBootstrap(userInfo: HomeUserInfo, petInfo: MainPet) {
+        self.userInfo = userInfo
+        self.petInfo = petInfo
+        navigationPath.removeLast(navigationPath.count)
+        rootView = .mainTab
     }
     
     func pop() {

--- a/DDanDDan/Entity/Friend/Friend.swift
+++ b/DDanDDan/Entity/Friend/Friend.swift
@@ -16,7 +16,7 @@ public struct FriendList: Decodable {
 public struct Friend: Decodable, Equatable, Hashable {
     public let id: String
     public let name: String
-    public let mainPetType: PetType
+    public let mainPetType: String
     public let petLevel: Int
 }
 
@@ -36,7 +36,7 @@ public struct AddedFriend: Decodable, Equatable {
 public struct FriendUser: Decodable, Equatable {
     let id: String
     let name: String
-    let mainPetType: PetType
+    let mainPetType: String
     let petLevel: Int
 }
 

--- a/DDanDDan/Entity/Home/HomeModel.swift
+++ b/DDanDDan/Entity/Home/HomeModel.swift
@@ -8,13 +8,53 @@
 import SwiftUI
 
 struct HomeModel {
-    var petType: PetType
+    var petType: String
     var level: Int
     var exp: Double
     var goalKcal: Int
     var feedCount: Int
     var toyCount: Int
     var ticket: Int
+}
+
+struct HomePetInteractionResponse: Equatable {
+    let petID: String
+    let petType: String
+    let level: Int
+    let expPercent: Double
+    let foodQuantity: Int
+    let toyQuantity: Int
+}
+
+struct HomePetInteractionState: Equatable {
+    let petID: String
+    let petType: String
+    let level: Int
+    let expPercent: Double
+    let foodQuantity: Int
+    let toyQuantity: Int
+    let presentation: PetPresentation
+}
+
+enum HomePetInteractionReducer {
+    static func reduce(
+        response: HomePetInteractionResponse,
+        catalog: PetCatalogSnapshot
+    ) -> HomePetInteractionState {
+        .init(
+            petID: response.petID,
+            petType: response.petType,
+            level: response.level,
+            expPercent: response.expPercent,
+            foodQuantity: response.foodQuantity,
+            toyQuantity: response.toyQuantity,
+            presentation: .resolve(
+                petType: response.petType,
+                petLevel: response.level,
+                snapshot: catalog
+            )
+        )
+    }
 }
 
 enum LottieMode {

--- a/DDanDDan/Entity/Home/WatchSharedHomeModel.swift
+++ b/DDanDDan/Entity/Home/WatchSharedHomeModel.swift
@@ -7,6 +7,55 @@
 
 import SwiftUI
 
+enum WatchPetSyncKey {
+    static let purposeKcal = "purposeKcal"
+    static let petType = "petType"
+    static let level = "level"
+    static let colorCode = "petColorCode"
+    static let assetIdentity = "petAssetIdentity"
+}
+
+struct WatchPetSyncMetadata: Equatable {
+    let purposeKcal: Int
+    let petType: String
+    let level: Int
+    let colorCode: String
+    let assetIdentity: String
+
+    var dictionary: [String: Any] {
+        [
+            WatchPetSyncKey.purposeKcal: purposeKcal,
+            WatchPetSyncKey.petType: petType,
+            WatchPetSyncKey.level: level,
+            WatchPetSyncKey.colorCode: colorCode,
+            WatchPetSyncKey.assetIdentity: assetIdentity
+        ]
+    }
+
+    init(purposeKcal: Int, petType: String, level: Int, colorCode: String, assetIdentity: String) {
+        self.purposeKcal = purposeKcal
+        self.petType = petType
+        self.level = level
+        self.colorCode = colorCode
+        self.assetIdentity = assetIdentity
+    }
+
+    init?(dictionary: [String: Any]) {
+        guard let purposeKcal = dictionary[WatchPetSyncKey.purposeKcal] as? NSNumber,
+              let petType = dictionary[WatchPetSyncKey.petType] as? String,
+              let level = dictionary[WatchPetSyncKey.level] as? NSNumber,
+              let colorCode = dictionary[WatchPetSyncKey.colorCode] as? String,
+              let assetIdentity = dictionary[WatchPetSyncKey.assetIdentity] as? String else { return nil }
+        self.init(
+            purposeKcal: purposeKcal.intValue,
+            petType: petType,
+            level: level.intValue,
+            colorCode: colorCode,
+            assetIdentity: assetIdentity
+        )
+    }
+}
+
 struct WatchPetModel: Codable {
     var petType: PetType
     var goalKcal: Int
@@ -80,5 +129,4 @@ public enum PetType: String, Codable {
         }
     }
 }
-
 

--- a/DDanDDan/Entity/Pet/Pet.swift
+++ b/DDanDDan/Entity/Pet/Pet.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct Pet: Decodable, Equatable {
     let id: String
-    let type: PetType
+    let type: String
     let level: Int
     let expPercent: Double
 }

--- a/DDanDDan/Entity/Pet/PetCatalog.swift
+++ b/DDanDDan/Entity/Pet/PetCatalog.swift
@@ -33,9 +33,7 @@ public struct PetCatalogLevel: Codable, Equatable, Sendable {
     public let lottiePlayEatUrl: String
 
     public var assetURLs: Set<URL> {
-        Set([imageUrl, lottieDefaultUrl, lottiePlayEatUrl].compactMap {
-            Self.absoluteHTTPURL($0)
-        })
+        Set([imageURL, defaultLottieURL, playEatLottieURL].compactMap { $0 })
     }
 
     public var imageURL: URL? { Self.absoluteHTTPURL(imageUrl, expectedExtension: "svg") }

--- a/DDanDDan/Entity/Pet/PetCatalog.swift
+++ b/DDanDDan/Entity/Pet/PetCatalog.swift
@@ -7,29 +7,101 @@
 
 import Foundation
 
-public struct PetCatalog: Codable, Equatable {
-    public let version: String
+public struct PetCatalogResponse: Codable, Equatable, Sendable {
+    public let revision: String
     public let pets: [PetCatalogItem]
 }
 
-public struct PetCatalogItem: Codable, Equatable {
+public struct PetCatalogItem: Codable, Equatable, Sendable {
     public let type: String
     public let name: String
+    public let colorCode: String
     public let displayOrder: Int
-    public let isActive: Bool
-    // 키 "1"~"5" 등 레벨 문자열. Int 키 변환은 후속 Repository에서 수행.
-    public let levels: [String: PetCatalogLevel]
-    public let backgrounds: PetCatalogBackgrounds
+    public let levels: [PetCatalogLevel]
+
+    public func selectedLevel(for petLevel: Int) -> PetCatalogLevel? {
+        levels
+            .filter { (1...5).contains($0.level) && $0.level <= petLevel }
+            .max { $0.level < $1.level }
+    }
 }
 
-public struct PetCatalogLevel: Codable, Equatable {
+public struct PetCatalogLevel: Codable, Equatable, Sendable {
+    public let level: Int
     public let imageUrl: String
     public let lottieDefaultUrl: String
     public let lottiePlayEatUrl: String
+
+    public var assetURLs: Set<URL> {
+        Set([imageUrl, lottieDefaultUrl, lottiePlayEatUrl].compactMap {
+            Self.absoluteHTTPURL($0)
+        })
+    }
+
+    public var imageURL: URL? { Self.absoluteHTTPURL(imageUrl, expectedExtension: "svg") }
+    public var defaultLottieURL: URL? { Self.absoluteHTTPURL(lottieDefaultUrl, expectedExtension: "json") }
+    public var playEatLottieURL: URL? { Self.absoluteHTTPURL(lottiePlayEatUrl, expectedExtension: "json") }
+
+    private static func absoluteHTTPURL(_ value: String, expectedExtension: String? = nil) -> URL? {
+        guard let url = URL(string: value),
+              ["http", "https"].contains(url.scheme?.lowercased() ?? ""),
+              url.host?.isEmpty == false,
+              expectedExtension == nil || url.pathExtension.lowercased() == expectedExtension else { return nil }
+        return url
+    }
 }
 
-public struct PetCatalogBackgrounds: Codable, Equatable {
-    public let homeUrl: String
-    public let homeCompactUrl: String
-    public let friendCardUrl: String
+public struct PetCatalogSnapshot: Equatable, Sendable {
+    public static let empty = PetCatalogSnapshot(revision: "", pets: [])
+
+    public let revision: String
+    public let pets: [PetCatalogItem]
+    public let catalogByType: [String: PetCatalogItem]
+
+    public init(revision: String, pets: [PetCatalogItem]) {
+        self.revision = revision
+        self.pets = pets.sorted { $0.displayOrder < $1.displayOrder }
+        self.catalogByType = pets.reduce(into: [:]) { result, item in
+            let key = Self.canonicalType(item.type)
+            guard !key.isEmpty else { return }
+            result[key] = item
+        }
+    }
+
+    public static func canonicalType(_ type: String) -> String {
+        type.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    public var assetURLs: Set<URL> {
+        Set(pets.flatMap { $0.levels.flatMap(\.assetURLs) })
+    }
+}
+
+public struct PetPresentation: Equatable, Sendable {
+    public let type: String
+    public let name: String
+    public let colorCode: String?
+    public let level: PetCatalogLevel?
+
+    public var usesPlaceholder: Bool { level == nil }
+
+    public static func resolve(petType: String, petLevel: Int, snapshot: PetCatalogSnapshot) -> Self {
+        let canonicalType = PetCatalogSnapshot.canonicalType(petType)
+        guard let item = snapshot.catalogByType[canonicalType] else {
+            return .init(type: petType, name: "알 수 없는 펫", colorCode: nil, level: nil)
+        }
+        return .init(
+            type: canonicalType,
+            name: item.name,
+            colorCode: Self.validHex(item.colorCode),
+            level: item.selectedLevel(for: petLevel).flatMap {
+                ($0.imageURL != nil || $0.defaultLottieURL != nil || $0.playEatLottieURL != nil) ? $0 : nil
+            }
+        )
+    }
+
+    private static func validHex(_ value: String) -> String? {
+        let pattern = "^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$"
+        return value.range(of: pattern, options: .regularExpression) == nil ? nil : value
+    }
 }

--- a/DDanDDan/Entity/Rank/Rank.swift
+++ b/DDanDDan/Entity/Rank/Rank.swift
@@ -33,7 +33,7 @@ public struct Ranking: Codable, Equatable, Identifiable {
     
     let rank: Int
     let userID, userName: String
-    let mainPetType: PetType
+    let mainPetType: String
     let petLevel, totalCalories, totalSucceededDays: Int
 
     enum CodingKeys: String, CodingKey {
@@ -65,4 +65,3 @@ struct TabRanking: Equatable {
     let kcal: RankInfo
     let goal: RankInfo
 }
-

--- a/DDanDDan/Network/AuthNetwork.swift
+++ b/DDanDDan/Network/AuthNetwork.swift
@@ -9,7 +9,11 @@ import Foundation
 import Alamofire
 
 public struct AuthNetwork {
-    private let manager = NetworkManager(withInterceptor: false)
+    private let manager: NetworkManager
+
+    public init(manager: NetworkManager = NetworkManager(withInterceptor: false)) {
+        self.manager = manager
+    }
     
     public func login(token: String, tokenType: String, deviceToken: String?) async -> Result<LoginData, NetworkError> {
         var parameter: Parameters = [

--- a/DDanDDan/Network/NetworkManager.swift
+++ b/DDanDDan/Network/NetworkManager.swift
@@ -9,13 +9,27 @@ import Foundation
 import Alamofire
 
 public struct NetworkManager {
-    private let baseURL = Config.baseURL
+    private let baseURL: String
     private let session: Session
+    private let responseHeaderHandler: any PetCatalogResponseHeaderHandling
     
-    public init(withInterceptor:Bool = true) {
-        let config = URLSessionConfiguration.default
+    public init(
+        withInterceptor: Bool = true,
+        revisionProvider: any PetCatalogRevisionProviding = PetCatalogRevisionStore.shared,
+        responseHeaderHandler: any PetCatalogResponseHeaderHandling = PetCatalogResponseHeaderHandler(),
+        configuration: URLSessionConfiguration = .default,
+        baseURL: String? = nil
+    ) {
+        let config = configuration
         config.requestCachePolicy = .useProtocolCachePolicy
-        self.session = Session(configuration: config, interceptor: withInterceptor ? TokenInterceptor() : nil)
+        let catalogInterceptor = PetCatalogHeaderInterceptor(revisionProvider: revisionProvider)
+        let interceptor = DDanDDanRequestInterceptor(
+            catalog: catalogInterceptor,
+            token: withInterceptor ? TokenInterceptor() : nil
+        )
+        self.session = Session(configuration: config, interceptor: interceptor)
+        self.responseHeaderHandler = responseHeaderHandler
+        self.baseURL = baseURL ?? Config.baseURL
     }
     
     private func createHeaders(excludeAuth: Bool = false, additionalHeaders: HTTPHeaders? = nil) -> HTTPHeaders {
@@ -74,6 +88,10 @@ public struct NetworkManager {
             result = await dataTask.serializingData(emptyResponseCodes: [200]).response
         } else {
             result = await dataTask.serializingData().response
+        }
+
+        if let response = result.response {
+            await responseHeaderHandler.handle(response: response, requestURL: url)
         }
         
         // 응답 로그 출력

--- a/DDanDDan/Network/PetCatalogHeaderInterceptor.swift
+++ b/DDanDDan/Network/PetCatalogHeaderInterceptor.swift
@@ -1,0 +1,54 @@
+import Alamofire
+import Foundation
+
+public final class PetCatalogHeaderInterceptor: RequestInterceptor, @unchecked Sendable {
+    public static let revisionHeader = "X-Pet-Catalog-Version"
+    private let revisionProvider: any PetCatalogRevisionProviding
+
+    public init(revisionProvider: any PetCatalogRevisionProviding = PetCatalogRevisionStore.shared) {
+        self.revisionProvider = revisionProvider
+    }
+
+    public func adapt(
+        _ urlRequest: URLRequest,
+        for session: Session,
+        completion: @escaping (Result<URLRequest, Error>) -> Void
+    ) {
+        var request = urlRequest
+        guard let path = request.url?.path, path.hasPrefix("/v1/") else {
+            completion(.success(request))
+            return
+        }
+        if path == "/v1/auth/login" {
+            request.setValue(nil, forHTTPHeaderField: Self.revisionHeader)
+        } else {
+            request.setValue(revisionProvider.currentRevision, forHTTPHeaderField: Self.revisionHeader)
+        }
+        completion(.success(request))
+    }
+}
+
+final class DDanDDanRequestInterceptor: RequestInterceptor, @unchecked Sendable {
+    private let catalog: PetCatalogHeaderInterceptor
+    private let token: TokenInterceptor?
+
+    init(catalog: PetCatalogHeaderInterceptor, token: TokenInterceptor?) {
+        self.catalog = catalog
+        self.token = token
+    }
+
+    func adapt(_ request: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        catalog.adapt(request, for: session) { [token] result in
+            guard case let .success(adapted) = result, let token else {
+                completion(result)
+                return
+            }
+            token.adapt(adapted, for: session, completion: completion)
+        }
+    }
+
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        guard let token else { return completion(.doNotRetryWithError(error)) }
+        token.retry(request, for: session, dueTo: error, completion: completion)
+    }
+}

--- a/DDanDDan/Network/PetCatalogHeaderInterceptor.swift
+++ b/DDanDDan/Network/PetCatalogHeaderInterceptor.swift
@@ -19,7 +19,7 @@ public final class PetCatalogHeaderInterceptor: RequestInterceptor, @unchecked S
             completion(.success(request))
             return
         }
-        if path == "/v1/auth/login" {
+        if path == PathString.Auth.login {
             request.setValue(nil, forHTTPHeaderField: Self.revisionHeader)
         } else {
             request.setValue(revisionProvider.currentRevision, forHTTPHeaderField: Self.revisionHeader)

--- a/DDanDDan/Network/PetCatalogNetwork.swift
+++ b/DDanDDan/Network/PetCatalogNetwork.swift
@@ -8,125 +8,14 @@
 import Foundation
 import Alamofire
 
-// TODO: 헤더(X-Pet-Catalog-Version) 노출 필요로 NetworkManager 미사용.
-// 후속 PR에서 NetworkManager에 헤더 반환 API 통합 검토.
-public struct PetCatalogNetwork {
-    private let baseURL = Config.baseURL
-    private let session: Session
+public protocol PetCatalogNetworking: Sendable {
+    func fetchCatalog() async -> Result<PetCatalogResponse, NetworkError>
+}
 
-    public init() {
-        let config = URLSessionConfiguration.default
-        config.requestCachePolicy = .useProtocolCachePolicy
-        self.session = Session(configuration: config, interceptor: TokenInterceptor())
-    }
+public struct PetCatalogNetwork: PetCatalogNetworking, Sendable {
+    public init() {}
 
-    /// 펫 카탈로그를 조회한다.
-    /// - Returns: 성공 시 디코딩된 `PetCatalog` 와 응답 헤더 `X-Pet-Catalog-Version` 값(없으면 nil).
-    public func fetchCatalog() async -> Result<(catalog: PetCatalog, version: String?), NetworkError> {
-        guard let url = URL(string: baseURL + PathString.Pet.catalog) else {
-            return .failure(NetworkError.urlError)
-        }
-
-        var headers: HTTPHeaders = [
-            "Content-Type": "application/json"
-        ]
-        if let accessToken = UserDefaultValue.accessToken {
-            headers["Authorization"] = "Bearer \(accessToken)"
-        }
-        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-            headers["X-iOS-Version"] = appVersion
-        }
-
-        // 토큰 노출 방지: Authorization 값을 redact한 사본만 로깅/Analytics로 전달.
-        var sanitizedHeaders = headers
-        if sanitizedHeaders["Authorization"] != nil {
-            sanitizedHeaders["Authorization"] = "Bearer <redacted>"
-        }
-
-        print("\n📡 Request:")
-        print("🔹 URL: \(url)")
-        print("🔹 Method: GET")
-        print("🔹 Headers: \(sanitizedHeaders)")
-
-        AnalyticsManager.shared.logEvent(
-            event: NetworkEvent.request(
-                url: url.absoluteString,
-                header: sanitizedHeaders.description,
-                params: nil
-            )
-        )
-
-        // NetworkManager와 동일하게 401까지 valid로 두어 TokenInterceptor retry 위임.
-        let dataTask = session.request(url, method: .get, headers: headers)
-            .validate(statusCode: 200..<401)
-        let result = await dataTask.serializingData().response
-
-        print("\n📥 Response:")
-        if let error = result.error {
-            print("🔹 AFError: \(error.localizedDescription)")
-
-            if let statusCode = error.responseCode {
-                if let data = result.data {
-                    do {
-                        let errorResponse = try JSONDecoder().decode(ServerErrorResponse.self, from: data)
-                        print("🔹 Server Error Code: \(errorResponse.code)")
-                        print("🔹 Server Error Message: \(errorResponse.message)")
-                        AnalyticsManager.shared.logEvent(event: NetworkEvent.onError(errorResponse))
-                        return .failure(NetworkError.serverError(statusCode, errorResponse.code))
-                    } catch {
-                        return .failure(NetworkError.failToDecode(error.localizedDescription))
-                    }
-                } else {
-                    print("🔹 Server Error: No data available")
-                    return .failure(NetworkError.serverError(statusCode, "Unknown error"))
-                }
-            }
-
-            return .failure(NetworkError.requestFailed(error.errorDescription ?? "Unknown error"))
-        }
-
-        guard let response = result.response else {
-            print("🔹 Error: Invalid response")
-            return .failure(NetworkError.invalidResponse)
-        }
-
-        print("🔹 Status Code: \(response.statusCode)")
-
-        // 400은 validate(200..<401)에서 valid로 흘러내려 오므로 NetworkManager와 동일하게 본문에서 ServerErrorResponse를 분리 디코드.
-        if response.statusCode == 400 {
-            guard let data = result.data else {
-                return .failure(NetworkError.dataNil)
-            }
-
-            do {
-                let errorResponse = try JSONDecoder().decode(ServerErrorResponse.self, from: data)
-                print("🔹 400 Error - Code: \(errorResponse.code), Message: \(errorResponse.message)")
-                AnalyticsManager.shared.logEvent(event: NetworkEvent.onError(errorResponse))
-                return .failure(NetworkError.serverError(400, errorResponse.code))
-            } catch {
-                print("🔹 400 Decoding Error: \(error.localizedDescription)")
-                return .failure(NetworkError.failToDecode(error.localizedDescription))
-            }
-        }
-
-        if 200..<300 ~= response.statusCode {
-            guard let data = result.data, !data.isEmpty else {
-                return .failure(NetworkError.dataNil)
-            }
-
-            do {
-                let catalog = try JSONDecoder().decode(PetCatalog.self, from: data)
-                // HTTPURLResponse.value(forHTTPHeaderField:) 는 case-insensitive.
-                let version = response.value(forHTTPHeaderField: "X-Pet-Catalog-Version")
-                print("🔹 Success: catalog version header = \(version ?? "nil"), body version = \(catalog.version)")
-                return .success((catalog: catalog, version: version))
-            } catch {
-                print("🔹 Decoding Error: \(error.localizedDescription)")
-                return .failure(NetworkError.failToDecode(error.localizedDescription))
-            }
-        } else {
-            print("🔹 Server Error: \(response.statusCode)")
-            return .failure(NetworkError.serverError(response.statusCode, response.description))
-        }
+    public func fetchCatalog() async -> Result<PetCatalogResponse, NetworkError> {
+        await NetworkManager().request(url: PathString.Pet.catalog, method: .get)
     }
 }

--- a/DDanDDan/Network/PetCatalogNetwork.swift
+++ b/DDanDDan/Network/PetCatalogNetwork.swift
@@ -13,9 +13,13 @@ public protocol PetCatalogNetworking: Sendable {
 }
 
 public struct PetCatalogNetwork: PetCatalogNetworking, Sendable {
-    public init() {}
+    private let manager: NetworkManager
+
+    public init(manager: NetworkManager = NetworkManager()) {
+        self.manager = manager
+    }
 
     public func fetchCatalog() async -> Result<PetCatalogResponse, NetworkError> {
-        await NetworkManager().request(url: PathString.Pet.catalog, method: .get)
+        await manager.request(url: PathString.Pet.catalog, method: .get)
     }
 }

--- a/DDanDDan/Network/PetCatalogResponseHeaderHandler.swift
+++ b/DDanDDan/Network/PetCatalogResponseHeaderHandler.swift
@@ -16,6 +16,7 @@ public struct PetCatalogResponseHeaderHandler: PetCatalogResponseHeaderHandling,
         let path = requestURL.path
         guard path.hasPrefix("/v1/"),
               path != PathString.Auth.login,
+              path != PathString.Auth.reissue,
               path != PathString.Pet.catalog,
               headerValue(in: response)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "true"
         else { return }

--- a/DDanDDan/Network/PetCatalogResponseHeaderHandler.swift
+++ b/DDanDDan/Network/PetCatalogResponseHeaderHandler.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public protocol PetCatalogResponseHeaderHandling: Sendable {
+    func handle(response: HTTPURLResponse, requestURL: URL) async
+}
+
+public struct PetCatalogResponseHeaderHandler: PetCatalogResponseHeaderHandling, Sendable {
+    public static let downloadRequiredHeader = "X-Pet-Catalog-Download-Required"
+    private let coordinator: any PetCatalogRefreshCoordinating
+
+    public init(coordinator: any PetCatalogRefreshCoordinating = PetCatalogRefreshCoordinator.shared) {
+        self.coordinator = coordinator
+    }
+
+    public func handle(response: HTTPURLResponse, requestURL: URL) async {
+        let path = requestURL.path
+        guard path.hasPrefix("/v1/"),
+              path != "/v1/auth/login",
+              path != "/v1/pets/catalog",
+              headerValue(in: response)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "true"
+        else { return }
+        await coordinator.requestRefresh()
+    }
+
+    private func headerValue(in response: HTTPURLResponse) -> String? {
+        if let value = response.value(forHTTPHeaderField: Self.downloadRequiredHeader) { return value }
+        for (key, value) in response.allHeaderFields {
+            if String(describing: key).caseInsensitiveCompare(Self.downloadRequiredHeader) == .orderedSame {
+                return String(describing: value)
+            }
+        }
+        return nil
+    }
+}

--- a/DDanDDan/Network/PetCatalogResponseHeaderHandler.swift
+++ b/DDanDDan/Network/PetCatalogResponseHeaderHandler.swift
@@ -15,8 +15,8 @@ public struct PetCatalogResponseHeaderHandler: PetCatalogResponseHeaderHandling,
     public func handle(response: HTTPURLResponse, requestURL: URL) async {
         let path = requestURL.path
         guard path.hasPrefix("/v1/"),
-              path != "/v1/auth/login",
-              path != "/v1/pets/catalog",
+              path != PathString.Auth.login,
+              path != PathString.Pet.catalog,
               headerValue(in: response)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "true"
         else { return }
         await coordinator.requestRefresh()

--- a/DDanDDan/Network/PetsNetwork.swift
+++ b/DDanDDan/Network/PetsNetwork.swift
@@ -30,9 +30,9 @@ public struct PetsNetwork {
     
     // MARK: - POST
     
-    public func addPet(accessToken: String, petType: PetType) async -> Result<Pet, NetworkError> {
+    public func addPet(accessToken: String, petType: String) async -> Result<Pet, NetworkError> {
         let parameter: Parameters = [
-            "petType": petType.rawValue
+            "petType": petType
         ]
         
         return await manager.request(
@@ -73,4 +73,3 @@ public struct PetsNetwork {
         )
     }
 }
-

--- a/DDanDDan/Network/TokenInterceptor.swift
+++ b/DDanDDan/Network/TokenInterceptor.swift
@@ -11,7 +11,6 @@ import Alamofire
 public final class TokenInterceptor: RequestInterceptor {
     
     private let maxRetryCount = 3
-    private var retryCount = 0
     private let tokenRefreshManager = TokenRefreshManager.shared
 
     public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
@@ -42,9 +41,8 @@ public final class TokenInterceptor: RequestInterceptor {
         
         print("🔹 Response Status Code: \(response.statusCode)")
         
-        if retryCount >= maxRetryCount {
+        if request.retryCount >= maxRetryCount {
             print("🔻 최대 재시도 횟수 초과: 로그아웃 처리")
-            retryCount = 0
             Task {
                 await UserManager.shared.logout()
             }
@@ -52,18 +50,15 @@ public final class TokenInterceptor: RequestInterceptor {
             return
         }
         
-        retryCount += 1
-        
-        
         Task {
-            let refreshSuccess = await tokenRefreshManager.refresh()
+            let refreshSuccess = await tokenRefreshManager.refresh(
+                failedRequestAuthorization: request.request?.value(forHTTPHeaderField: "Authorization")
+            )
             
             await MainActor.run {
                 if refreshSuccess {
-                    self.retryCount = 0
                     completion(.retry)
                 } else {
-                    self.retryCount = 0
                     completion(.doNotRetry)
                 }
             }

--- a/DDanDDan/Network/TokenRefreshManager.swift
+++ b/DDanDDan/Network/TokenRefreshManager.swift
@@ -9,52 +9,86 @@ import Foundation
 
 actor TokenRefreshManager {
     static let shared = TokenRefreshManager()
-    private init() {}
+    private let reissue: @Sendable (String) async -> Result<ReissueData, NetworkError>
+    private let applyReissue: @Sendable (ReissueData) async -> Void
+    private let logout: @Sendable () async -> Void
 
-    private var isRefreshing = false
+    init(
+        reissue: @escaping @Sendable (String) async -> Result<ReissueData, NetworkError> = { refreshToken in
+            await AuthNetwork().tokenReissue(refreshToken: refreshToken)
+        },
+        applyReissue: @escaping @Sendable (ReissueData) async -> Void = { reissueData in
+            UserDefaultValue.accessToken = reissueData.accessToken
+            UserDefaultValue.refreshToken = reissueData.refreshToken
+            await UserManager.shared.setToken(
+                accessToken: reissueData.accessToken,
+                refreshToken: reissueData.refreshToken
+            )
+        },
+        logout: @escaping @Sendable () async -> Void = {
+            await UserManager.shared.logout()
+        }
+    ) {
+        self.reissue = reissue
+        self.applyReissue = applyReissue
+        self.logout = logout
+    }
+
     private var refreshTask: Task<Bool, Never>?
+    private var failedAuthorization: String?
+    private var failedRefreshToken: String?
     
-    func refresh() async -> Bool {
+    func refresh(failedRequestAuthorization: String?) async -> Bool {
+        let currentAuthorization = UserDefaultValue.accessToken.map { "Bearer \($0)" }
+
+        // 이미 다른 요청이 토큰을 갱신했다면 실패했던 요청만 새 토큰으로 재시도한다.
+        if let failedRequestAuthorization,
+           let currentAuthorization,
+           failedRequestAuthorization != currentAuthorization {
+            return true
+        }
+
+        // 같은 만료 토큰의 재발급이 실패했다면 뒤늦게 도착한 401도 실패 결과를 공유한다.
+        if let failedAuthorization,
+           failedAuthorization == failedRequestAuthorization,
+           failedRefreshToken == UserDefaultValue.refreshToken {
+            return false
+        }
+
         if let existingTask = refreshTask {
             return await existingTask.value
         }
         
+        guard let refreshToken = UserDefaultValue.refreshToken, !refreshToken.isEmpty else {
+            failedAuthorization = failedRequestAuthorization
+            failedRefreshToken = nil
+            return false
+        }
+
+        let reissue = self.reissue
+        let applyReissue = self.applyReissue
+        let logout = self.logout
         let task = Task<Bool, Never> {
-            isRefreshing = true
-            
-            let network = AuthNetwork()
-            let refreshToken = UserDefaultValue.refreshToken ?? ""
-            let result = await network.tokenReissue(refreshToken: refreshToken)
+            let result = await reissue(refreshToken)
             
             switch result {
             case .success(let reissueData):
                 print("🔹 토큰 재발급 완료")
-                UserDefaultValue.accessToken = reissueData.accessToken
-                UserDefaultValue.refreshToken = reissueData.refreshToken
-                await UserManager.shared.setToken(
-                    accessToken: reissueData.accessToken,
-                    refreshToken: reissueData.refreshToken
-                )
+                await applyReissue(reissueData)
                 return true
                 
             case .failure(let failure):
                 print("🔻 토큰 재발급 실패: \(failure.localizedDescription)")
-                await UserManager.shared.logout()
+                await logout()
                 return false
             }
         }
         
         refreshTask = task
         let result = await task.value
-        
-        // Task 완료 후 정리
-        isRefreshing = false
         refreshTask = nil
-        
+        failedAuthorization = result ? nil : failedRequestAuthorization
+        failedRefreshToken = result ? nil : refreshToken
         return result
-    }
-    
-    var isCurrentlyRefreshing: Bool {
-        isRefreshing
     }
 }

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
@@ -30,7 +30,7 @@ struct FriendCardReducer {
         var showToast: Bool {
             !toastMessage.isEmpty
         }
-        var petLottieStrng: String {
+        var petType: String {
             guard let entity else { return "" }
             return entity.mainPet.type
         }

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardReducer.swift
@@ -32,7 +32,7 @@ struct FriendCardReducer {
         }
         var petLottieStrng: String {
             guard let entity else { return "" }
-            return entity.mainPet.type.lottieString(level: entity.mainPet.level)
+            return entity.mainPet.type
         }
         var hideButton: Bool {
             switch type {

--- a/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
+++ b/DDanDDan/Presenter/Components/FriendCard/FriendCardView.swift
@@ -9,12 +9,19 @@ import ComposableArchitecture
 import SwiftUI
 import Lottie
 
+@MainActor
 struct FriendCardView: View {
     let store: StoreOf<FriendCardReducer>
+    @ObservedObject private var catalogStore: PetCatalogStore
     @Environment(\.dismiss) var dismiss
     
-    init(store: StoreOf<FriendCardReducer>) {
+    init(store: StoreOf<FriendCardReducer>, catalogStore: PetCatalogStore) {
         self.store = store
+        self._catalogStore = ObservedObject(wrappedValue: catalogStore)
+    }
+
+    init(store: StoreOf<FriendCardReducer>) {
+        self.init(store: store, catalogStore: .shared)
     }
     
     var body: some View {
@@ -90,7 +97,12 @@ struct FriendCardView: View {
     var cardImageView: some View {
         Group {
             if let petType = store.entity?.mainPet.type {
-                PetBackground(pet: petType, surface: .friendCard)
+                let presentation = FriendCardCatalogResolver.presentation(
+                    petType: petType,
+                    petLevel: store.entity?.mainPet.level ?? 1,
+                    snapshot: catalogStore.snapshot
+                )
+                PetBackground(colorCode: presentation.colorCode, surface: .friendCard)
             } else {
                 Color.clear
             }
@@ -108,9 +120,7 @@ struct FriendCardView: View {
             }
         }
         .overlay(alignment: .bottom) {
-            LottieView(
-                animation: .named(store.petLottieStrng))
-            .playing(loopMode: .loop)
+            CatalogPetView(type: store.entity?.mainPet.type ?? "", level: store.entity?.mainPet.level ?? 0)
             .frame(width: 100, height: 100)
             .padding(.bottom, 23)
         }
@@ -212,6 +222,16 @@ struct FriendCardView: View {
     }
 }
 
+enum FriendCardCatalogResolver {
+    static func presentation(
+        petType: String,
+        petLevel: Int,
+        snapshot: PetCatalogSnapshot
+    ) -> PetPresentation {
+        .resolve(petType: petType, petLevel: petLevel, snapshot: snapshot)
+    }
+}
+
 // MARK: - Fire Emitter View
 struct FireEmitterView: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
@@ -279,7 +299,7 @@ struct FireEmitterView: UIViewRepresentable {
         store: Store(
             initialState: FriendCardReducer.State(
                 userID: "67cc3acbb0b10655fa4a37d6",
-                entity: .init(userId: "67cc3acbb0b10655fa4a37d6", userName: "지희", mainPet: .init(id: "", type: .greenHam, level: 2, expPercent: 29), todayCalorie: 100, monthlyReceivedCheerCount: 12, isFriend: true, isCheeredToday: false), type: .cheer
+                entity: .init(userId: "67cc3acbb0b10655fa4a37d6", userName: "지희", mainPet: .init(id: "", type: "HAMSTER", level: 2, expPercent: 29), todayCalorie: 100, monthlyReceivedCheerCount: 12, isFriend: true, isCheeredToday: false), type: .cheer
             )
         ) {
             FriendCardReducer()

--- a/DDanDDan/Presenter/Components/PetBackground.swift
+++ b/DDanDDan/Presenter/Components/PetBackground.swift
@@ -37,8 +37,21 @@ struct PetBackground: View {
     /// SVG 내 형태 fill의 원본 토큰. 모든 배경 SVG에서 동일하게 사용한다.
     private static let templateColorToken = "#FD85FF"
 
-    let pet: PetType
+    private let colorHex: String
+    private let fallbackColor: Color
     let surface: BackgroundSurface
+
+    init(pet: PetType, surface: BackgroundSurface) {
+        self.colorHex = pet.colorHex
+        self.fallbackColor = pet.color
+        self.surface = surface
+    }
+
+    init(colorCode: String?, surface: BackgroundSurface) {
+        self.colorHex = colorCode ?? "#D0DAE4"
+        self.fallbackColor = colorCode.map(Color.init(hex:)) ?? Color(.borderGray)
+        self.surface = surface
+    }
 
     var body: some View {
         Group {
@@ -48,7 +61,7 @@ struct PetBackground: View {
                     .allowsHitTesting(false)
             } else {
                 // 폴백: 번들 누락/디코딩 실패 시 펫 베이스 색 단색 표시
-                pet.color
+                fallbackColor
             }
         }
         .clipped()
@@ -66,7 +79,7 @@ struct PetBackground: View {
         // `#FD85FF`는 SVG 내 형태 fill에만 등장(white/#050000/none과 비충돌, 대문자 단일).
         return rawSVG.replacingOccurrences(
             of: Self.templateColorToken,
-            with: pet.colorHex
+            with: colorHex
         )
     }
 }

--- a/DDanDDan/Presenter/Components/RemotePetAssetView.swift
+++ b/DDanDDan/Presenter/Components/RemotePetAssetView.swift
@@ -1,0 +1,153 @@
+//
+//  RemotePetAssetView.swift
+//  DDanDDan
+//
+//  Created by Codex on 2026-07-01.
+//
+
+import SwiftUI
+import SVGView
+import Lottie
+
+enum RemotePetAssetLoader {
+    static func data(for url: URL, cache: any PetAssetCaching) async -> Data? {
+        if let data = await cache.data(for: url) { return data }
+        guard await cache.download(url) != nil else { return nil }
+        return await cache.data(for: url)
+    }
+}
+
+@MainActor
+final class RemotePetAssetLoadState: ObservableObject {
+    @Published private(set) var svg: String?
+    @Published private(set) var animation: LottieAnimation?
+    private(set) var currentIdentity: String?
+    private(set) var readyIdentity: String?
+    private(set) var failedIdentity: String?
+
+    var hasReadyContent: Bool { svg != nil || animation != nil }
+
+    func begin(identity: String) -> Bool {
+        currentIdentity = identity
+        return readyIdentity != identity
+    }
+
+    func commit(animation: LottieAnimation, identity: String) {
+        guard currentIdentity == identity else { return }
+        self.animation = animation
+        svg = nil
+        readyIdentity = identity
+        failedIdentity = nil
+    }
+
+    func commit(svg: String, identity: String) {
+        guard currentIdentity == identity else { return }
+        self.svg = svg
+        animation = nil
+        readyIdentity = identity
+        failedIdentity = nil
+    }
+
+    func fail(identity: String) {
+        guard currentIdentity == identity else { return }
+        failedIdentity = identity
+        guard !hasReadyContent else { return }
+        readyIdentity = nil
+    }
+
+    func showPlaceholder(identity: String) {
+        currentIdentity = identity
+        svg = nil
+        animation = nil
+        readyIdentity = nil
+        failedIdentity = nil
+    }
+}
+
+struct RemotePetAssetView: View {
+    enum Motion { case normal, playEat }
+
+    let presentation: PetPresentation
+    let motion: Motion
+    @StateObject private var loadState = RemotePetAssetLoadState()
+
+    var body: some View {
+        Group {
+            if let animation = loadState.animation {
+                LottieView(animation: animation).playing(loopMode: .loop)
+            } else if let svg = loadState.svg {
+                SVGView(string: svg).scaledToFit()
+            } else {
+                Image(.questionMark)
+                    .resizable()
+                    .scaledToFit()
+                    .accessibilityLabel("펫 이미지를 불러올 수 없어요")
+            }
+        }
+        .task(id: assetIdentity) { await load() }
+    }
+
+    private var assetIdentity: String {
+        guard let level = presentation.level else { return "placeholder" }
+        return motion == .normal ? level.lottieDefaultUrl : level.lottiePlayEatUrl
+    }
+
+    @MainActor
+    private func load() async {
+        let identity = assetIdentity
+        guard loadState.begin(identity: identity) else { return }
+        guard let level = presentation.level else {
+            loadState.showPlaceholder(identity: identity)
+            return
+        }
+        let lottieURL = motion == .normal ? level.defaultLottieURL : level.playEatLottieURL
+        if let url = lottieURL,
+           let data = await RemotePetAssetLoader.data(for: url, cache: PetAssetCache.shared),
+           let decoded = try? LottieAnimation.from(data: data) {
+            guard !Task.isCancelled, identity == assetIdentity else { return }
+            loadState.commit(animation: decoded, identity: identity)
+            return
+        }
+        guard !Task.isCancelled, identity == assetIdentity else { return }
+        if let url = lottieURL { await PetAssetCache.shared.invalidate(url) }
+        if let url = level.imageURL,
+           let data = await RemotePetAssetLoader.data(for: url, cache: PetAssetCache.shared) {
+            let value = String(data: data, encoding: .utf8)
+            guard !Task.isCancelled, identity == assetIdentity else { return }
+            if value?.lowercased().contains("<svg") == true {
+                loadState.commit(svg: value ?? "", identity: identity)
+                return
+            }
+            else { await PetAssetCache.shared.invalidate(url) }
+        }
+        guard !Task.isCancelled, identity == assetIdentity else { return }
+        loadState.fail(identity: identity)
+    }
+}
+
+@MainActor
+struct CatalogPetView: View {
+    @ObservedObject private var store = PetCatalogStore.shared
+    let type: String
+    let level: Int
+    var motion: RemotePetAssetView.Motion = .normal
+
+    var body: some View {
+        RemotePetAssetView(
+            presentation: .resolve(petType: type, petLevel: level, snapshot: store.snapshot),
+            motion: motion
+        )
+    }
+}
+
+@MainActor
+struct CatalogPetColor {
+    static func resolve(type: String) -> Color {
+        resolve(type: type, snapshot: PetCatalogStore.shared.snapshot)
+    }
+
+    static func resolve(type: String, snapshot: PetCatalogSnapshot) -> Color {
+        let presentation = PetPresentation.resolve(petType: type, petLevel: 1, snapshot: snapshot)
+        return presentation.colorCode.map(Color.init(hex:)) ?? Color(.borderGray)
+    }
+}

--- a/DDanDDan/Presenter/Components/RemotePetAssetView.swift
+++ b/DDanDDan/Presenter/Components/RemotePetAssetView.swift
@@ -88,8 +88,9 @@ struct RemotePetAssetView: View {
     }
 
     private var assetIdentity: String {
-        guard let level = presentation.level else { return "placeholder" }
-        return motion == .normal ? level.lottieDefaultUrl : level.lottiePlayEatUrl
+        guard let level = presentation.level else { return "\(presentation.type)-placeholder" }
+        let url = motion == .normal ? level.lottieDefaultUrl : level.lottiePlayEatUrl
+        return "\(presentation.type)-\(level.level)-\(motion)-\(url)"
     }
 
     @MainActor
@@ -103,7 +104,9 @@ struct RemotePetAssetView: View {
         let lottieURL = motion == .normal ? level.defaultLottieURL : level.playEatLottieURL
         if let url = lottieURL,
            let data = await RemotePetAssetLoader.data(for: url, cache: PetAssetCache.shared),
-           let decoded = try? LottieAnimation.from(data: data) {
+           let decoded = await Task.detached(priority: .userInitiated, operation: {
+               try? LottieAnimation.from(data: data)
+           }).value {
             guard !Task.isCancelled, identity == assetIdentity else { return }
             loadState.commit(animation: decoded, identity: identity)
             return
@@ -148,6 +151,10 @@ struct CatalogPetColor {
 
     static func resolve(type: String, snapshot: PetCatalogSnapshot) -> Color {
         let presentation = PetPresentation.resolve(petType: type, petLevel: 1, snapshot: snapshot)
-        return presentation.colorCode.map(Color.init(hex:)) ?? Color(.borderGray)
+        return resolve(presentation: presentation)
+    }
+
+    static func resolve(presentation: PetPresentation) -> Color {
+        presentation.colorCode.map(Color.init(hex:)) ?? Color(.borderGray)
     }
 }

--- a/DDanDDan/Presenter/Friends/FriendAddView.swift
+++ b/DDanDDan/Presenter/Friends/FriendAddView.swift
@@ -11,12 +11,12 @@ import Lottie
 struct FriendAddView: View {
     @ObservedObject var coordinator: AppCoordinator
     private let level: Int
-    private let petType: PetType
+    private let petType: String
     
     init(
         coordinator: AppCoordinator,
         level: Int,
-        petType: PetType
+        petType: String
     ) {
         self.coordinator = coordinator
         self.level = level
@@ -54,9 +54,7 @@ struct FriendAddView: View {
     var imageView: some View {
         ZStack {
             Image(.pangGraphics)
-            LottieView(animation: .named(petType.lottieString(level: level)))
-                .playing(loopMode: .playOnce)
-                .resizable()
+            CatalogPetView(type: petType, level: level)
                 .frame(width: 96, height: 96)
                 .aspectRatio(contentMode: .fill)
         }
@@ -65,5 +63,5 @@ struct FriendAddView: View {
 
 
 #Preview {
-    FriendAddView(coordinator: .init(), level: 2, petType: .bluePenguin)
+    FriendAddView(coordinator: .init(), level: 2, petType: "PENGUIN")
 }

--- a/DDanDDan/Presenter/Friends/FriendsModel.swift
+++ b/DDanDDan/Presenter/Friends/FriendsModel.swift
@@ -10,6 +10,6 @@ import Foundation
 // MARK: myProfile Model
 public struct ProfileModel: Equatable {
     let name: String
-    let petType: PetType
+    let petType: String
     let level: Int
 }

--- a/DDanDDan/Presenter/Friends/FriendsView.swift
+++ b/DDanDDan/Presenter/Friends/FriendsView.swift
@@ -126,10 +126,9 @@ struct FriendListView: View {
         HStack {
             ZStack {
                 Circle()
-                    .fill(friend.mainPetType.color)
+                    .fill(CatalogPetColor.resolve(type: friend.mainPetType))
                     .frame(width: 48, height: 48)
-                Image(friend.mainPetType.image(for: friend.petLevel))
-                    .resizable()
+                CatalogPetView(type: friend.mainPetType, level: friend.petLevel)
                     .frame(width: 38, height: 38)
                     .padding(3)
             }
@@ -170,10 +169,9 @@ struct FriendListView: View {
             HStack(alignment: .center) {
                 ZStack {
                     Circle()
-                        .fill(store.myProfilePet.petType.color)
+                        .fill(CatalogPetColor.resolve(type: store.myProfilePet.petType))
                         .frame(width: 48, height: 48)
-                    Image(store.myProfilePet.petType.image(for: store.myProfilePet.level))
-                        .resizable()
+                    CatalogPetView(type: store.myProfilePet.petType, level: store.myProfilePet.level)
                         .frame(width: 42, height: 42)
                         .offset(y: -3)
                 }

--- a/DDanDDan/Presenter/Friends/FriendsViewReducer.swift
+++ b/DDanDDan/Presenter/Friends/FriendsViewReducer.swift
@@ -27,7 +27,7 @@ struct FriendsViewReducer {
         var errorMessage: String?
         var myProfilePet: ProfileModel = .init(
             name: UserDefaultValue.nickName,
-            petType: PetType(rawValue: UserDefaultValue.petType) ?? .pinkCat,
+            petType: UserDefaultValue.petType,
             level: UserDefaultValue.level
         )
         var inviteCode: String = ""
@@ -75,7 +75,7 @@ struct FriendsViewReducer {
             case .onAppear:
                 state.myProfilePet = .init(
                     name: UserDefaultValue.nickName,
-                    petType: PetType(rawValue: UserDefaultValue.petType) ?? .pinkCat,
+                    petType: UserDefaultValue.petType,
                     level: UserDefaultValue.level
                 )
                 guard !state.hasLoadedOnce && !state.isLoading else {

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -13,8 +13,8 @@ import Lottie
 enum HomePath: Hashable {
     case successThreeDay(totalKcal: Int)
     case newPet
-    case upgradePet(level: Int, petType: PetType, newPetTicket: Bool)
-    case addFriend(level: Int, petType: PetType)
+    case upgradePet(level: Int, petType: String, newPetTicket: Bool)
+    case addFriend(level: Int, petType: String)
 }
 
 struct HomeView: View {
@@ -190,12 +190,12 @@ extension HomeView {
         ZStack {
             if isSEDevice {
                 PetBackground(
-                    pet: viewModel.homePetModel.petType,
+                    colorCode: viewModel.petPresentation.colorCode,
                     surface: .homeCompact
                 )
             } else {
                 PetBackground(
-                    pet: viewModel.homePetModel.petType,
+                    colorCode: viewModel.petPresentation.colorCode,
                     surface: .home
                 )
                 .frame(width: 254.adjusted, height: 370.adjusted)
@@ -219,15 +219,11 @@ extension HomeView {
     
     var petImage: some View {
         Group {
-            if viewModel.isPlayingSpecialAnimation {
-                LottieView(animation: .named(viewModel.currentLottieAnimation))
-                    .playing(loopMode: .loop)
-                    .frame(width: 100.adjusted, height: 100.adjusted)
-            } else {
-                LottieView(animation: .named(viewModel.homePetModel.petType.lottieString(level: viewModel.homePetModel.level)))
-                    .playing(loopMode: .loop)
-                    .frame(width: 100.adjusted, height: 100.adjusted)
-            }
+            RemotePetAssetView(
+                presentation: viewModel.petPresentation,
+                motion: viewModel.isPlayingSpecialAnimation ? .playEat : .normal
+            )
+            .frame(width: 100.adjusted, height: 100.adjusted)
         }
     }
     
@@ -260,7 +256,7 @@ extension HomeView {
                     ForEach(0..<25, id: \.self) { index in
                         if index < expCount {
                             Rectangle()
-                                .fill(viewModel.homePetModel.petType.color)
+                                .fill(viewModel.petPresentation.colorCode.map(Color.init(hex:)) ?? Color(.borderGray))
                                 .frame(width: 8.adjusted, height: 12)
                         } else {
                             Rectangle()

--- a/DDanDDan/Presenter/Home/HomeView.swift
+++ b/DDanDDan/Presenter/Home/HomeView.swift
@@ -256,7 +256,7 @@ extension HomeView {
                     ForEach(0..<25, id: \.self) { index in
                         if index < expCount {
                             Rectangle()
-                                .fill(viewModel.petPresentation.colorCode.map(Color.init(hex:)) ?? Color(.borderGray))
+                                .fill(CatalogPetColor.resolve(presentation: viewModel.petPresentation))
                                 .frame(width: 8.adjusted, height: 12)
                         } else {
                             Rectangle()

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -169,9 +169,10 @@ final class HomeViewModel: ObservableObject {
 
     @MainActor
     func fetchHomeInfo() async {
-        
-        let userData = await homeRepository.getUserInfo()
-        let mainPetData = await homeRepository.getMainPetInfo()
+        async let userInfoResult = homeRepository.getUserInfo()
+        async let mainPetResult = homeRepository.getMainPetInfo()
+        let userData = await userInfoResult
+        let mainPetData = await mainPetResult
         
         if case .success(let userInfo) = userData,
            case .success(let petInfo) = mainPetData {

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -194,13 +194,12 @@ final class HomeViewModel: ObservableObject {
             enableRandomPet = userInfo.tickets > 0
             resolvePresentation()
             
-            let info: [String: Any] = [
-                "purposeKcal": userInfo.purposeCalorie,
-                "petType": petInfo.mainPet.type,
-                "level": petInfo.mainPet.level
-            ]
-            
-            WatchConnectivityManager.shared.transferUserInfo(info: info)
+            await WatchConnectivityManager.shared.syncPet(
+                purposeKcal: userInfo.purposeCalorie,
+                petType: petInfo.mainPet.type,
+                level: petInfo.mainPet.level,
+                presentation: petPresentation
+            )
             
             
         }

--- a/DDanDDan/Presenter/Home/HomeViewModel.swift
+++ b/DDanDDan/Presenter/Home/HomeViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import HealthKit
 
 
+@MainActor
 final class HomeViewModel: ObservableObject {
     
     private struct Loading {
@@ -19,7 +20,7 @@ final class HomeViewModel: ObservableObject {
     }
     
     @Published var homePetModel: HomeModel = .init(
-        petType: PetType(rawValue: UserDefaultValue.petType) ?? .pinkCat,
+        petType: UserDefaultValue.petType,
         level: UserDefaultValue.level,
         exp: 0,
         goalKcal: UserDefaultValue.purposeKcal,
@@ -30,6 +31,11 @@ final class HomeViewModel: ObservableObject {
     
     @Published var isPlayingSpecialAnimation: Bool = false
     @Published var currentLottieAnimation: String = ""
+    @Published private(set) var petPresentation: PetPresentation = .resolve(
+        petType: UserDefaultValue.petType,
+        petLevel: UserDefaultValue.level,
+        snapshot: .empty
+    )
     
     @Published var isGoalMet: Bool = false
     @Published var isMaxLevel: Bool = false
@@ -64,6 +70,7 @@ final class HomeViewModel: ObservableObject {
     private var petId = ""
     private var previousKcal: Int = 0
     private var cancellables = Set<AnyCancellable>()
+    private let catalogStore: PetCatalogStore
     private var calorieTooltipToken: UUID?
     private var didAutoShowCalorieTooltip = false
     private var hasSeenHealthKitAuthorized = false
@@ -78,9 +85,11 @@ final class HomeViewModel: ObservableObject {
     init(
         repository: HomeRepositoryProtocol,
         userInfo: HomeUserInfo? = nil,
-        petInfo: MainPet? = nil
+        petInfo: MainPet? = nil,
+        catalogStore: PetCatalogStore = .shared
     ) {
         self.homeRepository = repository
+        self.catalogStore = catalogStore
         
         // 권한 체크
         checkHealthKitAuthorization()
@@ -101,6 +110,12 @@ final class HomeViewModel: ObservableObject {
             
             enableRandomPet = userInfo.tickets > 0
         }
+
+        catalogStore.$snapshot
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.resolvePresentation() }
+            .store(in: &cancellables)
+        resolvePresentation()
         
         observeHealthKitData()
     }
@@ -110,7 +125,7 @@ final class HomeViewModel: ObservableObject {
         guard !isPlayingSpecialAnimation else { return }
         
         isPlayingSpecialAnimation = true
-        currentLottieAnimation = homePetModel.petType.lottieString(level: homePetModel.level, mode: action)
+        currentLottieAnimation = action == .eatPlay ? "remote-play-eat" : "remote-default"
 
         // 햅틱
         let hapticDuration: Double = 1.0
@@ -142,13 +157,14 @@ final class HomeViewModel: ObservableObject {
     /// 이어 호출되는 fetchHomeInfo()가 일괄 덮어쓴다. 이 사이의 짧은 윈도우에서
     /// 위 카운트 필드들이 이전 값일 수 있다.
     @MainActor
-    func applyPetChange(petType: PetType, level: Int, expPercent: Double) {
+    func applyPetChange(petType: String, level: Int, expPercent: Double) {
         homePetModel.petType = petType
         homePetModel.level = level
         homePetModel.exp = expPercent
         // 변경 직후 이전 펫 애니메이션이 남지 않도록 특수 애니메이션 상태를 초기화한다.
         isPlayingSpecialAnimation = false
         currentLottieAnimation = ""
+        resolvePresentation()
     }
 
     @MainActor
@@ -160,7 +176,7 @@ final class HomeViewModel: ObservableObject {
         if case .success(let userInfo) = userData,
            case .success(let petInfo) = mainPetData {
             UserDefaultValue.userId = userInfo.id
-            UserDefaultValue.petType = petInfo.mainPet.type.rawValue
+            UserDefaultValue.petType = petInfo.mainPet.type
             UserDefaultValue.petId = petInfo.mainPet.id
             UserDefaultValue.purposeKcal = userInfo.purposeCalorie
             
@@ -176,10 +192,11 @@ final class HomeViewModel: ObservableObject {
             )
             
             enableRandomPet = userInfo.tickets > 0
+            resolvePresentation()
             
             let info: [String: Any] = [
                 "purposeKcal": userInfo.purposeCalorie,
-                "petType": petInfo.mainPet.type.rawValue,
+                "petType": petInfo.mainPet.type,
                 "level": petInfo.mainPet.level
             ]
             
@@ -203,7 +220,7 @@ final class HomeViewModel: ObservableObject {
             loadingState.feed = false
             switch result {
             case let .success(petData):
-                try await playFeedPet(petData: petData)
+                try await playFeedPet(petData: petData, bubble: .eat)
             case let .failure(error) :
                 await failToPlayWithPet(error: error)
             }
@@ -223,7 +240,7 @@ final class HomeViewModel: ObservableObject {
             let result = await homeRepository.playPet(petId: petId)
             switch result {
             case let .success(petData):
-                try await playFeedPet(petData: petData)
+                try await playFeedPet(petData: petData, bubble: .play)
             case let .failure(error) :
                 await failToPlayWithPet(error: error)
             }
@@ -242,29 +259,55 @@ final class HomeViewModel: ObservableObject {
     }
     
     @MainActor
-    private func playFeedPet(petData: UserPetData) async throws {
-        
-        self.homePetModel.toyCount = petData.user.toyQuantity
-        self.homePetModel.feedCount = petData.user.foodQuantity
-        self.homePetModel.exp = petData.pet.expPercent
+    private func playFeedPet(petData: UserPetData, bubble: bubbleTextType) async throws {
+        let interaction = HomePetInteractionReducer.reduce(
+            response: .init(
+                petID: petData.pet.id,
+                petType: petData.pet.type,
+                level: petData.pet.level,
+                expPercent: petData.pet.expPercent,
+                foodQuantity: petData.user.foodQuantity,
+                toyQuantity: petData.user.toyQuantity
+            ),
+            catalog: catalogStore.snapshot
+        )
+
+        self.homePetModel.toyCount = interaction.toyQuantity
+        self.homePetModel.feedCount = interaction.foodQuantity
+        self.homePetModel.exp = interaction.expPercent
+        self.petId = interaction.petID
+        UserDefaultValue.petId = interaction.petID
+        UserDefaultValue.petType = interaction.petType
         
         UserDefaultValue.level = petData.pet.level
         
         // 레벨 변화 확인
-        if self.homePetModel.level != petData.pet.level {
-            self.homePetModel.level = petData.pet.level
+        if self.homePetModel.level != interaction.level {
+            self.homePetModel.level = interaction.level
             self.isLevelUp = true
             self.isPlayingSpecialAnimation = false
             
-            if petData.pet.level == 5 {
+            if interaction.level == 5 {
                 self.isPlayingSpecialAnimation = false
                 self.isMaxLevel = true
             }
             
         }
 
-        self.showRandomBubble(type: .play)
+        self.homePetModel.petType = interaction.petType
+        self.petPresentation = interaction.presentation
+
+        self.showRandomBubble(type: bubble)
         try await self.updateLottieAnimation(for: .eatPlay)
+    }
+
+    @MainActor
+    private func resolvePresentation() {
+        petPresentation = PetPresentation.resolve(
+            petType: homePetModel.petType,
+            petLevel: homePetModel.level,
+            snapshot: catalogStore.snapshot
+        )
     }
     
     

--- a/DDanDDan/Presenter/Home/RandomGachaPetView.swift
+++ b/DDanDDan/Presenter/Home/RandomGachaPetView.swift
@@ -113,9 +113,10 @@ struct RandomGachaPetView: View {
                         .strokeBorder(Color.borderGray, lineWidth: 4)
                 )
             if viewModel.isSelectedRandomPet {
-                LottieView(animation: .named(viewModel.gachaResult?.type.lottieString(level: 1) ?? LottieString.randomEgg))
-                    .playing(loopMode: .loop)
-                    .frame(width: 130.adjustedHeight)
+                if let pet = viewModel.gachaResult {
+                    CatalogPetView(type: pet.type, level: pet.level)
+                        .frame(width: 130.adjustedHeight)
+                }
             } else {
                 LottieView(animation: .named(LottieString.randomEgg))
                     .playing(loopMode: .loop)

--- a/DDanDDan/Presenter/Home/Views/LevelUp/LevelUpView.swift
+++ b/DDanDDan/Presenter/Home/Views/LevelUp/LevelUpView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 struct LevelUpView: View {
     @ObservedObject var coordinator: AppCoordinator
     private let level: Int
-    private let petType: PetType
+    private let petType: String
     private let newRandomPet: Bool
     
     init(
         coordinator: AppCoordinator,
         level: Int,
-        petType: PetType,
+        petType: String,
         newRandomPet: Bool = false
     ) {
         self.coordinator = coordinator
@@ -64,8 +64,7 @@ struct LevelUpView: View {
     var imageView: some View {
         ZStack {
             Image(.pangGraphics)
-            Image(petType.image(for: level))
-                .resizable()
+            CatalogPetView(type: petType, level: level)
                 .frame(width: 96, height: 96)
                 .aspectRatio(contentMode: .fill)
         }
@@ -73,5 +72,5 @@ struct LevelUpView: View {
 }
 
 #Preview {
-    LevelUpView(coordinator: .init(), level: 4, petType: .bluePenguin)
+    LevelUpView(coordinator: .init(), level: 4, petType: "PENGUIN")
 }

--- a/DDanDDan/Presenter/Login/LoginView.swift
+++ b/DDanDDan/Presenter/Login/LoginView.swift
@@ -32,6 +32,7 @@ struct LoginView: View {
                         .foregroundColor(.black)
                         .padding(.horizontal, 20)
                 }
+                .opacity(viewModel.isLoading ? 0.5 : 1)
                 .disabled(viewModel.isLoading)
                 .padding(.bottom, 9)
                 Button {
@@ -46,6 +47,7 @@ struct LoginView: View {
                         .border(.white, width: 1)
                         .padding(.horizontal, 20)
                 }
+                .opacity(viewModel.isLoading ? 0.5 : 1)
                 .disabled(viewModel.isLoading)
             }
             .padding(.bottom, 40)

--- a/DDanDDan/Presenter/Login/LoginView.swift
+++ b/DDanDDan/Presenter/Login/LoginView.swift
@@ -32,6 +32,7 @@ struct LoginView: View {
                         .foregroundColor(.black)
                         .padding(.horizontal, 20)
                 }
+                .disabled(viewModel.isLoading)
                 .padding(.bottom, 9)
                 Button {
                     AnalyticsManager.shared.logEvent(event: LoginEvent.clickAppleBtn())
@@ -45,8 +46,18 @@ struct LoginView: View {
                         .border(.white, width: 1)
                         .padding(.horizontal, 20)
                 }
+                .disabled(viewModel.isLoading)
             }
             .padding(.bottom, 40)
+            if viewModel.isLoading {
+                ProgressView("펫 데이터를 준비하는 중이에요")
+                    .tint(.white)
+                    .foregroundStyle(.white)
+                    .padding(24)
+                    .background(Color(.backgroundBlack).opacity(0.85))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .accessibilityLabel("로그인 정보를 불러오는 중")
+            }
             TransparentOverlayView(isPresented: viewModel.showToast) {
                 VStack {
                     ToastView(message: viewModel.toastMessage, toastType: .info)

--- a/DDanDDan/Presenter/Login/LoginViewModel.swift
+++ b/DDanDDan/Presenter/Login/LoginViewModel.swift
@@ -11,14 +11,23 @@ import KakaoSDKCommon
 
 public class LoginViewModel: NSObject, ObservableObject {
     private let repository: LoginRepositoryProtocol
+    private let catalogRepository: any PetCatalogRepositoryProtocol
+    private let homeRepository: HomeRepositoryProtocol
     let appCoordinator: AppCoordinator
     
     @Published var toastMessage: String = "로그인에 실패했습니다."
     @Published var showToast: Bool = false
     
-    init(repository: LoginRepositoryProtocol, appCoordinator: AppCoordinator) {
+    init(
+        repository: LoginRepositoryProtocol,
+        appCoordinator: AppCoordinator,
+        catalogRepository: any PetCatalogRepositoryProtocol = PetCatalogRepository.shared,
+        homeRepository: HomeRepositoryProtocol = HomeRepository()
+    ) {
         self.repository = repository
         self.appCoordinator = appCoordinator
+        self.catalogRepository = catalogRepository
+        self.homeRepository = homeRepository
     }
     
     func appleLogin() {
@@ -62,6 +71,28 @@ public class LoginViewModel: NSObject, ObservableObject {
             switch result {
             case .success(let loginData):
                 await UserManager.shared.login(loginData: loginData)
+                if loginData.isOnboardingComplete {
+                    guard case let .success(mainPet) = await homeRepository.getMainPetInfo() else {
+                        DispatchQueue.main.async { [weak self] in self?.showToastMessage() }
+                        return
+                    }
+                    let bootstrap = await catalogRepository.prepareForMain(
+                        petType: mainPet.mainPet.type,
+                        level: mainPet.mainPet.level
+                    )
+                    guard case .success = bootstrap else {
+                        DispatchQueue.main.async { [weak self] in self?.showToastMessage() }
+                        return
+                    }
+                    await MainActor.run { [weak self] in
+                        self?.appCoordinator.petInfo = mainPet
+                        UserDefaultValue.petType = mainPet.mainPet.type
+                        UserDefaultValue.petId = mainPet.mainPet.id
+                        UserDefaultValue.level = mainPet.mainPet.level
+                    }
+                } else {
+                    await catalogRepository.startAuthenticatedRefresh()
+                }
                 await MainActor.run { [weak self] in
                     self?.appCoordinator.triggerHomeUpdate(trigger: true)
                     if loginData.isOnboardingComplete {

--- a/DDanDDan/Presenter/Login/LoginViewModel.swift
+++ b/DDanDDan/Presenter/Login/LoginViewModel.swift
@@ -17,6 +17,9 @@ public class LoginViewModel: NSObject, ObservableObject {
     
     @Published var toastMessage: String = "로그인에 실패했습니다."
     @Published var showToast: Bool = false
+    @Published private(set) var bootstrapState: AuthenticatedBootstrapState = .idle
+
+    var isLoading: Bool { bootstrapState == .loading }
     
     init(
         repository: LoginRepositoryProtocol,
@@ -65,7 +68,8 @@ public class LoginViewModel: NSObject, ObservableObject {
     private func login(token: String?, tokenType: String) {
         guard let token = token else { return }
         
-        Task {
+        Task { [weak self] in
+            guard let self, await self.beginLogin() else { return }
             await saveToken(token: token, tokenType: tokenType)
             let result = await repository.login(token: token, tokenType: tokenType)
             switch result {
@@ -73,7 +77,7 @@ public class LoginViewModel: NSObject, ObservableObject {
                 await UserManager.shared.login(loginData: loginData)
                 if loginData.isOnboardingComplete {
                     guard case let .success(mainPet) = await homeRepository.getMainPetInfo() else {
-                        DispatchQueue.main.async { [weak self] in self?.showToastMessage() }
+                        await failLogin(message: "메인 펫 정보를 확인하지 못했어요. 다시 시도해 주세요.")
                         return
                     }
                     let bootstrap = await catalogRepository.prepareForMain(
@@ -81,7 +85,7 @@ public class LoginViewModel: NSObject, ObservableObject {
                         level: mainPet.mainPet.level
                     )
                     guard case .success = bootstrap else {
-                        DispatchQueue.main.async { [weak self] in self?.showToastMessage() }
+                        await failLogin(message: "펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
                         return
                     }
                     await MainActor.run { [weak self] in
@@ -94,6 +98,7 @@ public class LoginViewModel: NSObject, ObservableObject {
                     await catalogRepository.startAuthenticatedRefresh()
                 }
                 await MainActor.run { [weak self] in
+                    self?.bootstrapState = .idle
                     self?.appCoordinator.triggerHomeUpdate(trigger: true)
                     if loginData.isOnboardingComplete {
                         self?.appCoordinator.setRoot(to: .mainTab)
@@ -110,11 +115,26 @@ public class LoginViewModel: NSObject, ObservableObject {
                         break
                     }
                     self?.showToastMessage()
+                    self?.bootstrapState = .failed(self?.toastMessage ?? "로그인에 실패했습니다.")
                 }
                 print(error)
                 
             }
         }
+    }
+
+    @MainActor
+    private func beginLogin() -> Bool {
+        guard bootstrapState != .loading else { return false }
+        bootstrapState = .loading
+        return true
+    }
+
+    @MainActor
+    private func failLogin(message: String) {
+        toastMessage = message
+        bootstrapState = .failed(message)
+        showToastMessage()
     }
     
     @MainActor

--- a/DDanDDan/Presenter/Login/LoginViewModel.swift
+++ b/DDanDDan/Presenter/Login/LoginViewModel.swift
@@ -13,6 +13,7 @@ public class LoginViewModel: NSObject, ObservableObject {
     private let repository: LoginRepositoryProtocol
     private let catalogRepository: any PetCatalogRepositoryProtocol
     private let homeRepository: HomeRepositoryProtocol
+    private let watchSyncer: any WatchPetSyncing
     let appCoordinator: AppCoordinator
     
     @Published var toastMessage: String = "로그인에 실패했습니다."
@@ -25,12 +26,14 @@ public class LoginViewModel: NSObject, ObservableObject {
         repository: LoginRepositoryProtocol,
         appCoordinator: AppCoordinator,
         catalogRepository: any PetCatalogRepositoryProtocol = PetCatalogRepository.shared,
-        homeRepository: HomeRepositoryProtocol = HomeRepository()
+        homeRepository: HomeRepositoryProtocol = HomeRepository(),
+        watchSyncer: any WatchPetSyncing = WatchConnectivityManager.shared
     ) {
         self.repository = repository
         self.appCoordinator = appCoordinator
         self.catalogRepository = catalogRepository
         self.homeRepository = homeRepository
+        self.watchSyncer = watchSyncer
     }
     
     func appleLogin() {
@@ -76,51 +79,76 @@ public class LoginViewModel: NSObject, ObservableObject {
             case .success(let loginData):
                 await UserManager.shared.login(loginData: loginData)
                 if loginData.isOnboardingComplete {
-                    guard case let .success(mainPet) = await homeRepository.getMainPetInfo() else {
-                        await failLogin(message: "메인 펫 정보를 확인하지 못했어요. 다시 시도해 주세요.")
-                        return
-                    }
-                    let bootstrap = await catalogRepository.prepareForMain(
-                        petType: mainPet.mainPet.type,
-                        level: mainPet.mainPet.level
-                    )
-                    guard case .success = bootstrap else {
-                        await failLogin(message: "펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
-                        return
-                    }
-                    await MainActor.run { [weak self] in
-                        self?.appCoordinator.petInfo = mainPet
-                        UserDefaultValue.petType = mainPet.mainPet.type
-                        UserDefaultValue.petId = mainPet.mainPet.id
-                        UserDefaultValue.level = mainPet.mainPet.level
-                    }
+                    guard await bootstrapCompletedUser() else { return }
+                    return
                 } else {
                     await catalogRepository.startAuthenticatedRefresh()
                 }
-                await MainActor.run { [weak self] in
-                    self?.bootstrapState = .idle
-                    self?.appCoordinator.triggerHomeUpdate(trigger: true)
-                    if loginData.isOnboardingComplete {
-                        self?.appCoordinator.setRoot(to: .mainTab)
-                    } else {
-                        self?.appCoordinator.setRoot(to: .signUp)
-                    }
-                }
+                await routeToSignUp()
             case .failure(let error):
-                await MainActor.run { [weak self] in
-                    switch error {
-                    case .serverError(_, let message):
-                        self?.toastMessage = "오류가 발생했습니다.: \(message)"
-                    case .dataNil, .encodingError, .failToDecode, .invalidResponse, .requestFailed, .urlError:
-                        break
-                    }
-                    self?.showToastMessage()
-                    self?.bootstrapState = .failed(self?.toastMessage ?? "로그인에 실패했습니다.")
-                }
+                await handleLoginFailure(error)
                 print(error)
                 
             }
         }
+    }
+
+    @MainActor
+    private func routeToSignUp() {
+        bootstrapState = .idle
+        appCoordinator.setRoot(to: .signUp)
+    }
+
+    @MainActor
+    private func handleLoginFailure(_ error: NetworkError) {
+        if case let .serverError(_, message) = error {
+            toastMessage = "오류가 발생했습니다.: \(message)"
+        }
+        showToastMessage()
+        bootstrapState = .failed(toastMessage)
+    }
+
+    @MainActor
+    func bootstrapCompletedUser() async -> Bool {
+        bootstrapState = .loading
+        async let userInfoResult = homeRepository.getUserInfo()
+        async let mainPetResult = homeRepository.getMainPetInfo()
+        guard case let .success(userInfo) = await userInfoResult,
+              case let .success(mainPet) = await mainPetResult else {
+            failLogin(message: "사용자와 메인 펫 정보를 확인하지 못했어요. 다시 시도해 주세요.")
+            return false
+        }
+        let bootstrap = await catalogRepository.prepareForMain(
+            petType: mainPet.mainPet.type,
+            level: mainPet.mainPet.level
+        )
+        guard case let .success(snapshot) = bootstrap else {
+            failLogin(message: "펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
+            return false
+        }
+        let presentation = PetPresentation.resolve(
+            petType: mainPet.mainPet.type,
+            petLevel: mainPet.mainPet.level,
+            snapshot: snapshot
+        )
+        guard presentation.level?.assetURLs.count == 3 else {
+            failLogin(message: "메인 펫 데이터를 찾을 수 없어요. 다시 시도해 주세요.")
+            return false
+        }
+        await watchSyncer.syncPet(
+            purposeKcal: userInfo.purposeCalorie,
+            petType: mainPet.mainPet.type,
+            level: mainPet.mainPet.level,
+            presentation: presentation
+        )
+        UserDefaultValue.petType = mainPet.mainPet.type
+        UserDefaultValue.petId = mainPet.mainPet.id
+        UserDefaultValue.level = mainPet.mainPet.level
+        UserDefaultValue.userId = userInfo.id
+        UserDefaultValue.purposeKcal = userInfo.purposeCalorie
+        appCoordinator.commitAuthenticatedBootstrap(userInfo: userInfo, petInfo: mainPet)
+        bootstrapState = .idle
+        return true
     }
 
     @MainActor
@@ -139,13 +167,17 @@ public class LoginViewModel: NSObject, ObservableObject {
     
     @MainActor
     private func saveToken(token: String, tokenType: String) {
+        UserManager.shared.loginCredential = .init(token: token, tokenType: tokenType)
         if tokenType == "KAKAO" {
             UserManager.shared.kakaoToken = token
+            UserManager.shared.appleToken = nil
         } else if tokenType == "APPLE" {
             UserManager.shared.appleToken = token
+            UserManager.shared.kakaoToken = nil
         }
     }
     
+    @MainActor
     private func showToastMessage() {
         showToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
@@ -153,6 +185,7 @@ public class LoginViewModel: NSObject, ObservableObject {
         }
     }
     
+    @MainActor
     private func hideToastMessage() {
         showToast = false
     }

--- a/DDanDDan/Presenter/Login/SignUp/SignUpCalorieView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpCalorieView.swift
@@ -44,15 +44,23 @@ struct SignUpCalorieView<ViewModel: SignUpViewModelProtocol>: View {
                     .padding(.top, 56)
                 
                 Spacer()
-                
+                if case let .failed(message) = viewModel.bootstrapState {
+                    Text(message)
+                        .font(.body2_regular14)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 12)
+                }
                 GreenButton(action: {
                     AnalyticsManager.shared.logEvent(event: SignUpEvent.clickCTA(touchpoint: "sign-up-goal"))
                     Task {
-                        //TODO: 실패처리
-                        await viewModel.updateCalorie(calorie: calorie)
-                        coordinator.push(to: .egg)
+                        if await viewModel.updateCalorie(calorie: calorie) {
+                            coordinator.push(to: .egg)
+                        }
                     }
-                }, title: "다음", disabled: false)
+                }, title: viewModel.bootstrapState == .loading ? "저장 중..." : "다음", disabled: viewModel.bootstrapState == .loading)
             }
             .navigationBarHidden(true)
         }

--- a/DDanDDan/Presenter/Login/SignUp/SignUpEggView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpEggView.swift
@@ -30,7 +30,15 @@ public struct SignUpEggView<ViewModel: SignUpViewModelProtocol>: View {
                 }
                 
                 Spacer()
-                
+                if case let .failed(message) = viewModel.bootstrapState {
+                    Text(message)
+                        .font(.body2_regular14)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 12)
+                }
                 GreenButton(action: {
                     AnalyticsManager.shared.logEvent(event: SignUpEvent.clickCTA(touchpoint: "sign-up-select-pet"))
                     guard let selectedEgg = selectedEgg else { return }
@@ -40,7 +48,7 @@ public struct SignUpEggView<ViewModel: SignUpViewModelProtocol>: View {
                         }
                     }
 
-                }, title: "다음", disabled: buttonDisabled)
+                }, title: viewModel.bootstrapState == .loading ? "설정 중..." : "다음", disabled: buttonDisabled || viewModel.bootstrapState == .loading)
                 .onChange(of: selectedEgg) { newValue in
                     buttonDisabled = selectedEgg == nil
                 }

--- a/DDanDDan/Presenter/Login/SignUp/SignUpNicknameView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpNicknameView.swift
@@ -39,7 +39,15 @@ public struct SignUpNicknameView<ViewModel: SignUpViewModelProtocol>: View {
                 .padding(.horizontal, 20)
                 
                 Spacer()
-                
+                if case let .failed(message) = viewModel.bootstrapState {
+                    Text(message)
+                        .font(.body2_regular14)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 12)
+                }
                 GreenButton(action: {
                     AnalyticsManager.shared.logEvent(event: SignUpEvent.clickNextCTA)
                     Task {
@@ -47,7 +55,7 @@ public struct SignUpNicknameView<ViewModel: SignUpViewModelProtocol>: View {
                             coordinator.push(to: .calorie)
                         }
                     }
-                }, title: "다음", disabled: buttonDisabled)
+                }, title: viewModel.bootstrapState == .loading ? "저장 중..." : "다음", disabled: buttonDisabled || viewModel.bootstrapState == .loading)
                 .onChange(of: nickname) { newValue in
                     buttonDisabled = nickname.isEmpty
                 }

--- a/DDanDDan/Presenter/Login/SignUp/SignUpSuccessView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpSuccessView.swift
@@ -30,15 +30,24 @@ struct SignUpSuccessView<ViewModel: SignUpViewModelProtocol>: View {
                 .frame(maxWidth: .infinity)
                 .padding(.top, 64)
                 Spacer()
-                
+                if case let .failed(message) = viewModel.bootstrapState {
+                    Text(message)
+                        .font(.body2_regular14)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 12)
+                }
                 GreenButton(action: {
                     AnalyticsManager.shared.logEvent(event: SignUpEvent.clickCTA(touchpoint: "sign-up-start"))
                     Task {
-                        await viewModel.login()
+                        guard await viewModel.login() else { return }
+                        coordinator.petInfo = viewModel.preparedMainPet
                         coordinator.triggerHomeUpdate(trigger: true)
                         coordinator.setRoot(to: .mainTab)
                     }
-                }, title: "시작하기", disabled: false)
+                }, title: viewModel.bootstrapState == .loading ? "준비 중..." : "시작하기", disabled: viewModel.bootstrapState == .loading)
             }
         }
         .navigationBarHidden(true)

--- a/DDanDDan/Presenter/Login/SignUp/SignUpSuccessView.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpSuccessView.swift
@@ -43,9 +43,9 @@ struct SignUpSuccessView<ViewModel: SignUpViewModelProtocol>: View {
                     AnalyticsManager.shared.logEvent(event: SignUpEvent.clickCTA(touchpoint: "sign-up-start"))
                     Task {
                         guard await viewModel.login() else { return }
-                        coordinator.petInfo = viewModel.preparedMainPet
-                        coordinator.triggerHomeUpdate(trigger: true)
-                        coordinator.setRoot(to: .mainTab)
+                        guard let userInfo = viewModel.preparedUserInfo,
+                              let mainPet = viewModel.preparedMainPet else { return }
+                        coordinator.commitAuthenticatedBootstrap(userInfo: userInfo, petInfo: mainPet)
                     }
                 }, title: viewModel.bootstrapState == .loading ? "준비 중..." : "시작하기", disabled: viewModel.bootstrapState == .loading)
             }

--- a/DDanDDan/Presenter/Login/SignUp/SignUpViewModel.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpViewModel.swift
@@ -7,22 +7,34 @@
 
 import Foundation
 
+@MainActor
 public protocol SignUpViewModelProtocol: ObservableObject {
+    var bootstrapState: AuthenticatedBootstrapState { get }
+    var preparedMainPet: MainPet? { get }
     func updateNickname(name: String) async -> Bool
     func updateCalorie(calorie: Int) async -> Bool
     func login() async -> Bool
     func updatePet(petType: PetType) async -> Bool
 }
+@MainActor
 final class SignUpViewModel: SignUpViewModelProtocol {
     private let repository: SignUpRepositoryProtocol
-    init(repository: SignUpRepositoryProtocol) {
+    private let catalogRepository: any PetCatalogRepositoryProtocol
+    @Published private(set) var bootstrapState: AuthenticatedBootstrapState = .idle
+    @Published private(set) var preparedMainPet: MainPet?
+
+    init(
+        repository: SignUpRepositoryProtocol,
+        catalogRepository: any PetCatalogRepositoryProtocol = PetCatalogRepository.shared
+    ) {
         self.repository = repository
+        self.catalogRepository = catalogRepository
     }
     public func updatePet(petType: PetType) async -> Bool {
-        let result = await repository.addPet(petType: petType)
+        let result = await repository.addPet(petType: petType.rawValue)
         switch result {
         case .success(let pet):
-            UserDefaultValue.petType = pet.type.rawValue
+            UserDefaultValue.petType = pet.type
             UserDefaultValue.petId = pet.id
             return await setMainPet(petID: pet.id)
         case .failure(let failure):
@@ -34,8 +46,11 @@ final class SignUpViewModel: SignUpViewModelProtocol {
     private func setMainPet(petID: String) async -> Bool {
         let result = await repository.setMainPet(petID: petID)
         switch result {
-        case .success:
-            
+        case let .success(mainPet):
+            preparedMainPet = mainPet
+            UserDefaultValue.petType = mainPet.mainPet.type
+            UserDefaultValue.petId = mainPet.mainPet.id
+            UserDefaultValue.level = mainPet.mainPet.level
             return true
         case .failure(let failure):
             // TODO: 에러 처리
@@ -67,14 +82,32 @@ final class SignUpViewModel: SignUpViewModelProtocol {
     }
     
     public func login() async -> Bool {
-        guard let kakaoToken = repository.getKakaoToken() else { return false}
+        guard bootstrapState != .loading else { return false }
+        bootstrapState = .loading
+        guard let kakaoToken = repository.getKakaoToken() else {
+            bootstrapState = .failed("로그인 정보를 확인하지 못했어요. 다시 시도해 주세요.")
+            return false
+        }
         let result = await repository.login(token: kakaoToken, tokenType: "KAKAO")
         switch result {
         case .success(let loginData):
             await UserManager.shared.login(loginData: loginData)
+            guard let mainPet = preparedMainPet else {
+                bootstrapState = .failed("메인 펫 정보를 확인하지 못했어요. 다시 시도해 주세요.")
+                return false
+            }
+            let bootstrap = await catalogRepository.prepareForMain(
+                petType: mainPet.mainPet.type,
+                level: mainPet.mainPet.level
+            )
+            guard case let .success(snapshot) = bootstrap, !snapshot.pets.isEmpty else {
+                bootstrapState = .failed("펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
+                return false
+            }
+            bootstrapState = .idle
             return true
         case .failure(let failure):
-            // TODO: 에러 처리
+            bootstrapState = .failed("로그인에 실패했어요. 다시 시도해 주세요.")
             return false
         }
     }

--- a/DDanDDan/Presenter/Login/SignUp/SignUpViewModel.swift
+++ b/DDanDDan/Presenter/Login/SignUp/SignUpViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 public protocol SignUpViewModelProtocol: ObservableObject {
     var bootstrapState: AuthenticatedBootstrapState { get }
     var preparedMainPet: MainPet? { get }
+    var preparedUserInfo: HomeUserInfo? { get }
     func updateNickname(name: String) async -> Bool
     func updateCalorie(calorie: Int) async -> Bool
     func login() async -> Bool
@@ -20,25 +21,33 @@ public protocol SignUpViewModelProtocol: ObservableObject {
 final class SignUpViewModel: SignUpViewModelProtocol {
     private let repository: SignUpRepositoryProtocol
     private let catalogRepository: any PetCatalogRepositoryProtocol
+    private let homeRepository: HomeRepositoryProtocol
+    private let watchSyncer: any WatchPetSyncing
     @Published private(set) var bootstrapState: AuthenticatedBootstrapState = .idle
     @Published private(set) var preparedMainPet: MainPet?
+    @Published private(set) var preparedUserInfo: HomeUserInfo?
 
     init(
         repository: SignUpRepositoryProtocol,
-        catalogRepository: any PetCatalogRepositoryProtocol = PetCatalogRepository.shared
+        catalogRepository: any PetCatalogRepositoryProtocol = PetCatalogRepository.shared,
+        homeRepository: HomeRepositoryProtocol = HomeRepository(),
+        watchSyncer: any WatchPetSyncing = WatchConnectivityManager.shared
     ) {
         self.repository = repository
         self.catalogRepository = catalogRepository
+        self.homeRepository = homeRepository
+        self.watchSyncer = watchSyncer
     }
     public func updatePet(petType: PetType) async -> Bool {
+        bootstrapState = .loading
         let result = await repository.addPet(petType: petType.rawValue)
         switch result {
         case .success(let pet):
             UserDefaultValue.petType = pet.type
             UserDefaultValue.petId = pet.id
             return await setMainPet(petID: pet.id)
-        case .failure(let failure):
-            // TODO: 에러 처리
+        case .failure:
+            bootstrapState = .failed("펫을 추가하지 못했어요. 다시 시도해 주세요.")
             return false
         }
     }
@@ -51,32 +60,36 @@ final class SignUpViewModel: SignUpViewModelProtocol {
             UserDefaultValue.petType = mainPet.mainPet.type
             UserDefaultValue.petId = mainPet.mainPet.id
             UserDefaultValue.level = mainPet.mainPet.level
+            bootstrapState = .idle
             return true
-        case .failure(let failure):
-            // TODO: 에러 처리
+        case .failure:
+            bootstrapState = .failed("메인 펫을 설정하지 못했어요. 다시 시도해 주세요.")
             return false
         }
     }
     
     public func updateNickname(name: String) async -> Bool {
+        bootstrapState = .loading
         let result = await repository.update(name: name, purposeCalorie: 100)
         switch result {
         case .success:
+            bootstrapState = .idle
             return true
-        case .failure(let failure):
-            // TODO: 에러 처리
+        case .failure:
+            bootstrapState = .failed("별명을 저장하지 못했어요. 다시 시도해 주세요.")
             return false
         }
     }
     public func updateCalorie(calorie: Int) async -> Bool {
+        bootstrapState = .loading
         let name = UserDefaultValue.nickName
         let result = await repository.update(name: name, purposeCalorie: calorie)
-        UserDefaultValue.purposeKcal = calorie
         switch result {
         case .success:
+            bootstrapState = .idle
             return true
-        case .failure(let failure):
-            // TODO: 에러 처리
+        case .failure:
+            bootstrapState = .failed("목표 칼로리를 저장하지 못했어요. 다시 시도해 주세요.")
             return false
         }
     }
@@ -84,15 +97,18 @@ final class SignUpViewModel: SignUpViewModelProtocol {
     public func login() async -> Bool {
         guard bootstrapState != .loading else { return false }
         bootstrapState = .loading
-        guard let kakaoToken = repository.getKakaoToken() else {
+        guard let credential = repository.getLoginCredential() else {
             bootstrapState = .failed("로그인 정보를 확인하지 못했어요. 다시 시도해 주세요.")
             return false
         }
-        let result = await repository.login(token: kakaoToken, tokenType: "KAKAO")
+        let result = await repository.login(token: credential.token, tokenType: credential.tokenType)
         switch result {
         case .success(let loginData):
             await UserManager.shared.login(loginData: loginData)
-            guard let mainPet = preparedMainPet else {
+            async let userInfoResult = homeRepository.getUserInfo()
+            async let mainPetResult = homeRepository.getMainPetInfo()
+            guard case let .success(userInfo) = await userInfoResult,
+                  case let .success(mainPet) = await mainPetResult else {
                 bootstrapState = .failed("메인 펫 정보를 확인하지 못했어요. 다시 시도해 주세요.")
                 return false
             }
@@ -100,13 +116,32 @@ final class SignUpViewModel: SignUpViewModelProtocol {
                 petType: mainPet.mainPet.type,
                 level: mainPet.mainPet.level
             )
-            guard case let .success(snapshot) = bootstrap, !snapshot.pets.isEmpty else {
+            guard case let .success(snapshot) = bootstrap else {
                 bootstrapState = .failed("펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
                 return false
             }
+            let presentation = PetPresentation.resolve(
+                petType: mainPet.mainPet.type,
+                petLevel: mainPet.mainPet.level,
+                snapshot: snapshot
+            )
+            guard presentation.level?.assetURLs.count == 3 else {
+                bootstrapState = .failed("선택한 펫 데이터를 찾을 수 없어요. 다시 시도해 주세요.")
+                return false
+            }
+            await watchSyncer.syncPet(
+                purposeKcal: userInfo.purposeCalorie,
+                petType: mainPet.mainPet.type,
+                level: mainPet.mainPet.level,
+                presentation: presentation
+            )
+            preparedUserInfo = userInfo
+            preparedMainPet = mainPet
+            UserDefaultValue.userId = userInfo.id
+            UserDefaultValue.purposeKcal = userInfo.purposeCalorie
             bootstrapState = .idle
             return true
-        case .failure(let failure):
+        case .failure:
             bootstrapState = .failed("로그인에 실패했어요. 다시 시도해 주세요.")
             return false
         }

--- a/DDanDDan/Presenter/Rank/RankContentsView.swift
+++ b/DDanDDan/Presenter/Rank/RankContentsView.swift
@@ -168,10 +168,9 @@ extension RankContentsView {
             
             ZStack {
                 Circle()
-                    .fill(rank.mainPetType.color)
+                    .fill(CatalogPetColor.resolve(type: rank.mainPetType))
                     .frame(width: 48, height: 48)
-                Image(rank.mainPetType.image(for: rank.petLevel))
-                    .resizable()
+                CatalogPetView(type: rank.mainPetType, level: rank.petLevel)
                     .frame(width: 38, height: 38)
                     .offset(y: rank.petLevel > 3 ? 0 : -3)
                     .padding(3)
@@ -230,10 +229,9 @@ extension RankContentsView {
                         .padding(.trailing, 12)
                     ZStack {
                         Circle()
-                            .fill(myRanking?.mainPetType.color ?? .blueGraphics)
+                            .fill(myRanking.map { CatalogPetColor.resolve(type: $0.mainPetType) } ?? Color(.borderGray))
                             .frame(width: 48, height: 48)
-                        Image(myRanking?.mainPetType.image(for: myRanking?.petLevel ?? 0) ?? .blueEgg)
-                            .resizable()
+                        CatalogPetView(type: myRanking?.mainPetType ?? "", level: myRanking?.petLevel ?? 0)
                             .frame(width: 42, height: 42)
                             .offset(y: -3)
                     }
@@ -293,8 +291,7 @@ struct RankCard: View {
     var body: some View {
         ZStack {
             VStack {
-                Image(ranking.mainPetType.image(for: ranking.petLevel))
-                    .resizable()
+                CatalogPetView(type: ranking.mainPetType, level: ranking.petLevel)
                     .frame(width: 64, height: 64)
                     .padding(.bottom, 10)
                 VStack {

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveView.swift
@@ -88,8 +88,7 @@ struct PetArchiveView: View {
                         
                     
                     if let pet = pet {
-                        Image(pet.type.image(for: pet.level))
-                            .resizable()
+                        CatalogPetView(type: pet.type, level: pet.level)
                             .aspectRatio(contentMode: .fit)
                             .frame(maxWidth: 80, maxHeight: 80)
                     } else {

--- a/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
+++ b/DDanDDan/Presenter/Setting/Archive/PetArchiveViewModel.swift
@@ -123,7 +123,7 @@ final class PetArchiveViewModel: ObservableObject {
         let result = await homeRepository.updateMainPet(petId: id)
         if case .success(let pet) = result {
             UserDefaultValue.petId = pet.mainPet.id
-            UserDefaultValue.petType = pet.mainPet.type.rawValue
+            UserDefaultValue.petType = pet.mainPet.type
             // 메인 펫이 바뀌었으므로 보관함 캐시 무효화 — 다음 진입 시 새 fetch.
             await cache.invalidate()
             await MainActor.run { [weak self] in

--- a/DDanDDan/Presenter/Splash/SplashView.swift
+++ b/DDanDDan/Presenter/Splash/SplashView.swift
@@ -23,6 +23,20 @@ struct SplashView: View {
                 Image(.splashLogo)
                 Spacer()
                 Image(.splashStart)
+                if case let .failed(message) = viewModel.bootstrapState {
+                    Text(message)
+                        .font(.body2_regular14)
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 12)
+                    GreenButton(
+                        action: { Task { await viewModel.retryInitialSetup() } },
+                        title: "다시 시도",
+                        disabled: false
+                    )
+                    .padding(.horizontal, 20)
+                }
             }
         }
         .alert("업데이트 필요", isPresented: $showUpdateAlert) {

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 
 public enum AuthenticatedBootstrapState: Equatable {
     case idle
@@ -15,6 +16,7 @@ public enum AuthenticatedBootstrapState: Equatable {
 
 @MainActor
 final class SplashViewModel: ObservableObject {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "DDanDDan", category: "Splash")
     private let coordinator: AppCoordinator
     private let homeRepository: HomeRepositoryProtocol
     private let catalogRepository: any PetCatalogRepositoryProtocol
@@ -43,6 +45,7 @@ final class SplashViewModel: ObservableObject {
                 level: petData.mainPet.level
             )
             guard case .success = catalogBootstrap else {
+                Self.logger.error("Pet catalog bootstrap failed: \(String(describing: catalogBootstrap), privacy: .public)")
                 bootstrapState = .failed("펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
                 return
             }
@@ -67,6 +70,7 @@ final class SplashViewModel: ObservableObject {
             coordinator.commitAuthenticatedBootstrap(userInfo: userData, petInfo: petData)
             bootstrapState = .idle
         } catch {
+            Self.logger.error("Initial setup failed: \(error.localizedDescription, privacy: .public)")
             bootstrapState = .failed("정보를 불러오지 못했어요. 다시 시도해 주세요.")
         }
     }

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -6,57 +6,74 @@
 //
 
 import Foundation
+
+public enum AuthenticatedBootstrapState: Equatable {
+    case idle
+    case loading
+    case failed(String)
+}
+
+@MainActor
 final class SplashViewModel: ObservableObject {
     private let coordinator: AppCoordinator
-    private let homeRepository: HomeRepository
+    private let homeRepository: HomeRepositoryProtocol
+    private let catalogRepository: any PetCatalogRepositoryProtocol
     
     @Published var updateAlertMessage: String = ""
+    @Published private(set) var bootstrapState: AuthenticatedBootstrapState = .idle
     
     init(
         coordinator: AppCoordinator,
-        homeRepository: HomeRepository
+        homeRepository: HomeRepositoryProtocol,
+        catalogRepository: any PetCatalogRepositoryProtocol = PetCatalogRepository.shared
     ) {
         self.coordinator = coordinator
         self.homeRepository = homeRepository
+        self.catalogRepository = catalogRepository
     }
     
     func performInitialSetup() async {
+        guard bootstrapState != .loading else { return }
+        bootstrapState = .loading
         do {
             let userData = try await unwrapResult(homeRepository.getUserInfo())
-
-            await MainActor.run {
-                self.coordinator.userInfo = userData
-                UserDefaultValue.userId = userData.id
-                UserDefaultValue.purposeKcal = userData.purposeCalorie
-            }
-
             let petData = try await unwrapResult(homeRepository.getMainPetInfo())
-
-            await MainActor.run {
-                self.coordinator.petInfo = petData
-                UserDefaultValue.petType = petData.mainPet.type.rawValue
-                UserDefaultValue.petId = petData.mainPet.id
-                UserDefaultValue.level = petData.mainPet.level
-                
-                
-                let sharedDefaults = UserDefaults(suiteName: "group.com.DdanDdan")
-                sharedDefaults?.set(petData.mainPet.type.rawValue, forKey: "petType")
-                sharedDefaults?.set(petData.mainPet.level, forKey: "petLevel")
-                sharedDefaults?.synchronize()
-
-                let info: [String: Any] = [
-                    "purposeKcal": userData.purposeCalorie,
-                    "petType": petData.mainPet.type.rawValue,
-                    "level": petData.mainPet.level
-                ]
-                WatchConnectivityManager.shared.transferUserInfo(info: info)
-                self.coordinator.setRoot(to: .mainTab)
+            let catalogBootstrap = await catalogRepository.prepareForMain(
+                petType: petData.mainPet.type,
+                level: petData.mainPet.level
+            )
+            guard case .success = catalogBootstrap else {
+                bootstrapState = .failed("펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
+                return
             }
+
+            UserDefaultValue.userId = userData.id
+            UserDefaultValue.purposeKcal = userData.purposeCalorie
+            UserDefaultValue.petType = petData.mainPet.type
+            UserDefaultValue.petId = petData.mainPet.id
+            UserDefaultValue.level = petData.mainPet.level
+
+            let sharedDefaults = UserDefaults(suiteName: "group.com.DdanDdan")
+            sharedDefaults?.set(petData.mainPet.type, forKey: "petType")
+            sharedDefaults?.set(petData.mainPet.level, forKey: "petLevel")
+            sharedDefaults?.synchronize()
+
+            let info: [String: Any] = [
+                "purposeKcal": userData.purposeCalorie,
+                "petType": petData.mainPet.type,
+                "level": petData.mainPet.level
+            ]
+            WatchConnectivityManager.shared.transferUserInfo(info: info)
+            coordinator.commitAuthenticatedBootstrap(userInfo: userData, petInfo: petData)
+            bootstrapState = .idle
         } catch {
-            await MainActor.run {
-                self.coordinator.setRoot(to: .login)
-            }
+            bootstrapState = .failed("정보를 불러오지 못했어요. 다시 시도해 주세요.")
         }
+    }
+
+    func retryInitialSetup() async {
+        guard bootstrapState != .loading else { return }
+        await performInitialSetup()
     }
     
     @MainActor

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -44,7 +44,7 @@ final class SplashViewModel: ObservableObject {
                 petType: petData.mainPet.type,
                 level: petData.mainPet.level
             )
-            guard case .success = catalogBootstrap else {
+            guard case let .success(snapshot) = catalogBootstrap else {
                 Self.logger.error("Pet catalog bootstrap failed: \(String(describing: catalogBootstrap), privacy: .public)")
                 bootstrapState = .failed("펫 데이터를 준비하지 못했어요. 다시 시도해 주세요.")
                 return
@@ -61,12 +61,17 @@ final class SplashViewModel: ObservableObject {
             sharedDefaults?.set(petData.mainPet.level, forKey: "petLevel")
             sharedDefaults?.synchronize()
 
-            let info: [String: Any] = [
-                "purposeKcal": userData.purposeCalorie,
-                "petType": petData.mainPet.type,
-                "level": petData.mainPet.level
-            ]
-            WatchConnectivityManager.shared.transferUserInfo(info: info)
+            let presentation = PetPresentation.resolve(
+                petType: petData.mainPet.type,
+                petLevel: petData.mainPet.level,
+                snapshot: snapshot
+            )
+            await WatchConnectivityManager.shared.syncPet(
+                purposeKcal: userData.purposeCalorie,
+                petType: petData.mainPet.type,
+                level: petData.mainPet.level,
+                presentation: presentation
+            )
             coordinator.commitAuthenticatedBootstrap(userInfo: userData, petInfo: petData)
             bootstrapState = .idle
         } catch {

--- a/DDanDDan/Presenter/Splash/SplashViewModel.swift
+++ b/DDanDDan/Presenter/Splash/SplashViewModel.swift
@@ -38,8 +38,10 @@ final class SplashViewModel: ObservableObject {
         guard bootstrapState != .loading else { return }
         bootstrapState = .loading
         do {
-            let userData = try await unwrapResult(homeRepository.getUserInfo())
-            let petData = try await unwrapResult(homeRepository.getMainPetInfo())
+            async let userInfoResult = homeRepository.getUserInfo()
+            async let mainPetResult = homeRepository.getMainPetInfo()
+            let userData = try await unwrapResult(userInfoResult)
+            let petData = try await unwrapResult(mainPetResult)
             let catalogBootstrap = await catalogRepository.prepareForMain(
                 petType: petData.mainPet.type,
                 level: petData.mainPet.level

--- a/DDanDDan/Repository/Dependencies/RepositoryDependency.swift
+++ b/DDanDDan/Repository/Dependencies/RepositoryDependency.swift
@@ -12,4 +12,9 @@ extension DependencyValues {
         get { self[FriendCardRepository.self] }
         set { self[FriendCardRepository.self] = newValue }
     }
+
+    var petCatalogRepository: PetCatalogRepository {
+        get { self[PetCatalogRepository.self] }
+        set { self[PetCatalogRepository.self] = newValue }
+    }
 }

--- a/DDanDDan/Repository/HomeRepository.swift
+++ b/DDanDDan/Repository/HomeRepository.swift
@@ -18,7 +18,7 @@ public protocol HomeRepositoryProtocol {
     func updateMainPet(petId: String) async -> Result<MainPet, NetworkError>
     func feedPet(petId: String) async -> Result<UserPetData, NetworkError>
     func playPet(petId: String) async -> Result<UserPetData, NetworkError>
-    func addNewPet(petType: PetType) async -> Result<Pet, NetworkError>
+    func addNewPet(petType: String) async -> Result<Pet, NetworkError>
     func addNewRandomPet() async -> Result<Pet, NetworkError>
     func addNewGachaRandomPet() async -> Result<Pet, NetworkError>
     
@@ -107,7 +107,7 @@ public struct HomeRepository: HomeRepositoryProtocol {
         return result
     }
     
-    public func addNewPet(petType: PetType) async -> Result<Pet, NetworkError> {
+    public func addNewPet(petType: String) async -> Result<Pet, NetworkError> {
         guard let accessToken = await UserManager.shared.accessToken else { return .failure(.requestFailed("Access Token Nil"))}
         
         let result = await petNetwork.addPet(accessToken: accessToken, petType: petType)

--- a/DDanDDan/Repository/PetCatalogRefreshCoordinator.swift
+++ b/DDanDDan/Repository/PetCatalogRefreshCoordinator.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public protocol PetCatalogRefreshCoordinating: Sendable {
+    func requestRefresh() async
+}
+
+public actor PetCatalogRefreshCoordinator: PetCatalogRefreshCoordinating {
+    public static let shared = PetCatalogRefreshCoordinator {
+        _ = await PetCatalogRepository.shared.sync()
+    }
+
+    private let refresh: @Sendable () async -> Void
+    private var inflight: Task<Void, Never>?
+    private var inflightID: UUID?
+
+    public init(refresh: @escaping @Sendable () async -> Void) {
+        self.refresh = refresh
+    }
+
+    public func requestRefresh() {
+        guard inflight == nil else { return }
+        let id = UUID()
+        let refresh = self.refresh
+        let task = Task { await refresh() }
+        inflight = task
+        inflightID = id
+        Task { [weak self] in
+            await task.value
+            await self?.finish(id: id)
+        }
+    }
+
+    private func finish(id: UUID) {
+        guard inflightID == id else { return }
+        inflight = nil
+        inflightID = nil
+    }
+}

--- a/DDanDDan/Repository/PetCatalogRepository.swift
+++ b/DDanDDan/Repository/PetCatalogRepository.swift
@@ -1,0 +1,234 @@
+//
+//  PetCatalogRepository.swift
+//  DDanDDan
+//
+//  Created by Codex on 2026-07-01.
+//
+
+import Foundation
+import Dependencies
+
+@MainActor
+public final class PetCatalogStore: ObservableObject {
+    public static let shared = PetCatalogStore()
+    @Published public private(set) var snapshot: PetCatalogSnapshot = .empty
+
+    public func publish(_ snapshot: PetCatalogSnapshot) {
+        guard self.snapshot != snapshot else { return }
+        self.snapshot = snapshot
+    }
+}
+
+public struct PetAssetBatchResult: Equatable, Sendable {
+    public let cacheHits: Set<URL>
+    public let downloaded: Set<URL>
+    public let failures: Set<URL>
+
+    public var isComplete: Bool { failures.isEmpty }
+}
+
+public protocol PetCatalogRepositoryProtocol: Sendable {
+    @discardableResult func loadLocal() async -> PetCatalogSnapshot
+    @discardableResult func sync() async -> Result<PetCatalogSnapshot, NetworkError>
+    @discardableResult func prepareForMain(petType: String, level: Int) async -> Result<PetCatalogSnapshot, NetworkError>
+    @discardableResult func bootstrapAfterAuthentication() async -> Result<PetCatalogSnapshot, NetworkError>
+}
+
+public extension PetCatalogRepositoryProtocol {
+    func prepareForMain(petType: String, level: Int) async -> Result<PetCatalogSnapshot, NetworkError> {
+        await bootstrapAfterAuthentication()
+    }
+
+    /// 인증 완료 후 카탈로그를 준비한다. 로컬이 있으면 즉시 반환하고 서버 갱신은 background에서 수행한다.
+    /// 로컬이 비어 있으면 첫 화면 진입 전에 server snapshot publish까지 기다린다.
+    func bootstrapAfterAuthentication() async -> Result<PetCatalogSnapshot, NetworkError> {
+        let local = await loadLocal()
+        if !local.pets.isEmpty {
+            return .success(local)
+        }
+        return await sync()
+    }
+
+    /// sign-up처럼 메인 UI를 아직 표시하지 않는 인증 경로에서 blocking 없이 갱신을 시작한다.
+    func startAuthenticatedRefresh() async {
+        _ = await loadLocal()
+        Task { _ = await sync() }
+    }
+}
+
+public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
+    public static let shared = PetCatalogRepository()
+
+    private let network: any PetCatalogNetworking
+    private let storage: any PetCatalogStoring
+    private let cache: any PetAssetCaching
+    private var snapshot: PetCatalogSnapshot = .empty
+    private var inflight: Task<Result<PetCatalogSnapshot, NetworkError>, Never>?
+    private var inflightID: UUID?
+    private var generation: UInt64 = 0
+
+    public init(
+        network: any PetCatalogNetworking = PetCatalogNetwork(),
+        storage: any PetCatalogStoring = PetCatalogStorage(),
+        cache: any PetAssetCaching = PetAssetCache.shared
+    ) {
+        self.network = network
+        self.storage = storage
+        self.cache = cache
+    }
+
+    @discardableResult
+    public func loadLocal() async -> PetCatalogSnapshot {
+        guard let catalog = await storage.load() else {
+            return snapshot
+        }
+        let local = PetCatalogSnapshot(revision: catalog.revision, pets: catalog.pets)
+        guard snapshot != local else { return snapshot }
+        snapshot = local
+        generation &+= 1
+        await publish(snapshot)
+        return snapshot
+    }
+
+    @discardableResult
+    public func bootstrapAfterAuthentication() async -> Result<PetCatalogSnapshot, NetworkError> {
+        await prepareForMain(petType: UserDefaultValue.petType, level: UserDefaultValue.level)
+    }
+
+    @discardableResult
+    public func prepareForMain(petType: String, level: Int) async -> Result<PetCatalogSnapshot, NetworkError> {
+        let local = await loadLocal()
+        if !local.pets.isEmpty {
+            let presentation = PetPresentation.resolve(petType: petType, petLevel: level, snapshot: local)
+            guard let selectedLevel = presentation.level else {
+                return .failure(.requestFailed("메인 펫 카탈로그를 찾을 수 없습니다."))
+            }
+            let requiredURLs = selectedLevel.assetURLs
+            guard requiredURLs.count == 3 else {
+                return .failure(.requestFailed("메인 펫 에셋 URL이 유효하지 않습니다."))
+            }
+            let result = await download(requiredURLs)
+            guard result.isComplete else {
+                return .failure(.requestFailed("필수 펫 에셋을 준비하지 못했습니다."))
+            }
+            Task { _ = await sync() }
+            return .success(local)
+        }
+        return await sync()
+    }
+
+    @discardableResult
+    public func sync() async -> Result<PetCatalogSnapshot, NetworkError> {
+        if let inflight { return await inflight.value }
+
+        let taskID = UUID()
+        let expectedGeneration = generation
+        let oldSnapshot = snapshot
+        let task = Task<Result<PetCatalogSnapshot, NetworkError>, Never> { [weak self] in
+            guard let self else { return .failure(.requestFailed("PetCatalogRepository released")) }
+            return await self.performSync(expectedGeneration: expectedGeneration, oldSnapshot: oldSnapshot)
+        }
+        inflight = task
+        inflightID = taskID
+        let result = await task.value
+        if inflightID == taskID {
+            inflight = nil
+            inflightID = nil
+        }
+        return result
+    }
+
+    private func performSync(
+        expectedGeneration: UInt64,
+        oldSnapshot: PetCatalogSnapshot
+    ) async -> Result<PetCatalogSnapshot, NetworkError> {
+        let response = await network.fetchCatalog()
+        guard case let .success(catalog) = response else {
+            if case let .failure(error) = response { return .failure(error) }
+            return .failure(.invalidResponse)
+        }
+
+        if catalog.revision == oldSnapshot.revision {
+            let missingURLs = await oldSnapshot.assetURLs.asyncFilter { !(await cache.contains($0)) }
+            _ = await download(missingURLs)
+            return .success(snapshot)
+        }
+
+        let candidate = PetCatalogSnapshot(revision: catalog.revision, pets: catalog.pets)
+        guard !candidate.pets.isEmpty else {
+            return .failure(.invalidResponse)
+        }
+        let expectedAssetCount = catalog.pets.reduce(0) { $0 + ($1.levels.count * 3) }
+        guard expectedAssetCount > 0,
+              candidate.assetURLs.count == expectedAssetCount else {
+            return .failure(.invalidResponse)
+        }
+        let urlsToDownload = await candidate.assetURLs.asyncFilter {
+            let isNewURL = !oldSnapshot.assetURLs.contains($0)
+            if isNewURL { return true }
+            let isCached = await cache.contains($0)
+            return !isCached
+        }
+        let batch = await download(urlsToDownload)
+        let alreadyCachedCount = candidate.assetURLs.count - urlsToDownload.count
+        guard batch.isComplete,
+              alreadyCachedCount + batch.cacheHits.count + batch.downloaded.count == expectedAssetCount else {
+            return .failure(.requestFailed("펫 카탈로그 에셋 다운로드에 실패했습니다."))
+        }
+
+        guard expectedGeneration == generation else { return .success(snapshot) }
+        do {
+            try await storage.save(catalog)
+        } catch {
+            return .failure(.requestFailed(error.localizedDescription))
+        }
+        snapshot = candidate
+        generation &+= 1
+        await publish(candidate)
+        return .success(candidate)
+    }
+
+    private func download(_ urls: Set<URL>) async -> PetAssetBatchResult {
+        let cache = self.cache
+        var hits = Set<URL>()
+        var downloaded = Set<URL>()
+        var failures = Set<URL>()
+        let pending = Array(urls)
+        for start in stride(from: 0, to: pending.count, by: 8) {
+            let end = min(start + 8, pending.count)
+            let results = await withTaskGroup(of: (URL, Bool, Bool).self, returning: [(URL, Bool, Bool)].self) { group in
+                for url in pending[start..<end] {
+                    group.addTask {
+                        if await cache.contains(url) { return (url, true, true) }
+                        return (url, false, await cache.download(url) != nil)
+                    }
+                }
+                var values: [(URL, Bool, Bool)] = []
+                for await value in group { values.append(value) }
+                return values
+            }
+            for (url, wasHit, success) in results {
+                if wasHit { hits.insert(url) }
+                else if success { downloaded.insert(url) }
+                else { failures.insert(url) }
+            }
+        }
+        return .init(cacheHits: hits, downloaded: downloaded, failures: failures)
+    }
+
+    private func publish(_ snapshot: PetCatalogSnapshot) async {
+        await PetCatalogStore.shared.publish(snapshot)
+    }
+}
+
+extension PetCatalogRepository: DependencyKey {
+    public static let liveValue = PetCatalogRepository.shared
+}
+
+private extension Sequence where Element == URL {
+    func asyncFilter(_ predicate: (URL) async -> Bool) async -> Set<URL> {
+        var result = Set<URL>()
+        for element in self where await predicate(element) { result.insert(element) }
+        return result
+    }
+}

--- a/DDanDDan/Repository/PetCatalogRepository.swift
+++ b/DDanDDan/Repository/PetCatalogRepository.swift
@@ -49,10 +49,10 @@ public extension PetCatalogRepositoryProtocol {
         return await sync()
     }
 
-    /// sign-up처럼 메인 UI를 아직 표시하지 않는 인증 경로에서 blocking 없이 갱신을 시작한다.
+    /// sign-up 진입 시 로컬 카탈로그만 publish한다.
+    /// 선택 펫이 확정되기 전 전체 에셋을 다운로드하지 않고, 가입 완료의 prepareForMain이 필수 에셋만 준비한다.
     func startAuthenticatedRefresh() async {
         _ = await loadLocal()
-        Task { _ = await sync() }
     }
 }
 
@@ -65,6 +65,7 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
     private var snapshot: PetCatalogSnapshot = .empty
     private var inflight: Task<Result<PetCatalogSnapshot, NetworkError>, Never>?
     private var inflightID: UUID?
+    private var inflightDownloadsAllAssets = false
     private var generation: UInt64 = 0
 
     public init(
@@ -98,49 +99,79 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
     @discardableResult
     public func prepareForMain(petType: String, level: Int) async -> Result<PetCatalogSnapshot, NetworkError> {
         let local = await loadLocal()
-        if !local.pets.isEmpty {
-            let presentation = PetPresentation.resolve(petType: petType, petLevel: level, snapshot: local)
-            guard let selectedLevel = presentation.level else {
-                return await sync()
-            }
-            let requiredURLs = selectedLevel.assetURLs
-            guard requiredURLs.count == 3 else {
-                return .failure(.requestFailed("메인 펫 에셋 URL이 유효하지 않습니다."))
-            }
-            let result = await download(requiredURLs)
-            guard result.isComplete else {
-                return .failure(.requestFailed("필수 펫 에셋을 준비하지 못했습니다."))
-            }
-            Task { _ = await sync() }
-            return .success(local)
+        let prepared: PetCatalogSnapshot
+        let usedLocalCatalog: Bool
+        if requiredAssetURLs(petType: petType, level: level, snapshot: local) != nil {
+            prepared = local
+            usedLocalCatalog = true
+        } else {
+            let synced = await sync(requiredMainPet: (petType, level))
+            guard case let .success(snapshot) = synced else { return synced }
+            prepared = snapshot
+            usedLocalCatalog = false
         }
-        return await sync()
+
+        guard let requiredURLs = requiredAssetURLs(petType: petType, level: level, snapshot: prepared) else {
+            return .failure(.requestFailed("메인 펫 카탈로그를 찾을 수 없습니다."))
+        }
+        let result = await download(requiredURLs)
+        guard result.isComplete else {
+            return .failure(.requestFailed("필수 펫 에셋을 준비하지 못했습니다."))
+        }
+        if usedLocalCatalog {
+            Task { _ = await sync() }
+        }
+        return .success(prepared)
     }
 
     @discardableResult
     public func sync() async -> Result<PetCatalogSnapshot, NetworkError> {
-        if let inflight { return await inflight.value }
+        await sync(requiredMainPet: nil)
+    }
+
+    private func sync(
+        requiredMainPet: (type: String, level: Int)?
+    ) async -> Result<PetCatalogSnapshot, NetworkError> {
+        if let inflight {
+            let joinedID = inflightID
+            let joinedDownloadsAllAssets = inflightDownloadsAllAssets
+            let result = await inflight.value
+            guard requiredMainPet == nil, !joinedDownloadsAllAssets else { return result }
+            if inflightID == joinedID {
+                self.inflight = nil
+                inflightID = nil
+                inflightDownloadsAllAssets = false
+            }
+            return await sync(requiredMainPet: nil)
+        }
 
         let taskID = UUID()
         let expectedGeneration = generation
         let oldSnapshot = snapshot
         let task = Task<Result<PetCatalogSnapshot, NetworkError>, Never> { [weak self] in
             guard let self else { return .failure(.requestFailed("PetCatalogRepository released")) }
-            return await self.performSync(expectedGeneration: expectedGeneration, oldSnapshot: oldSnapshot)
+            return await self.performSync(
+                expectedGeneration: expectedGeneration,
+                oldSnapshot: oldSnapshot,
+                requiredMainPet: requiredMainPet
+            )
         }
         inflight = task
         inflightID = taskID
+        inflightDownloadsAllAssets = requiredMainPet == nil
         let result = await task.value
         if inflightID == taskID {
             inflight = nil
             inflightID = nil
+            inflightDownloadsAllAssets = false
         }
         return result
     }
 
     private func performSync(
         expectedGeneration: UInt64,
-        oldSnapshot: PetCatalogSnapshot
+        oldSnapshot: PetCatalogSnapshot,
+        requiredMainPet: (type: String, level: Int)?
     ) async -> Result<PetCatalogSnapshot, NetworkError> {
         let response = await network.fetchCatalog()
         guard case let .success(catalog) = response else {
@@ -149,8 +180,21 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
         }
 
         if catalog.revision == oldSnapshot.revision {
-            let missingURLs = await oldSnapshot.assetURLs.asyncFilter { !(await cache.contains($0)) }
-            _ = await download(missingURLs)
+            let targetURLs: Set<URL>
+            if let requiredMainPet {
+                guard let required = requiredAssetURLs(
+                    petType: requiredMainPet.type,
+                    level: requiredMainPet.level,
+                    snapshot: oldSnapshot
+                ) else { return .failure(.invalidResponse) }
+                targetURLs = required
+            } else {
+                targetURLs = oldSnapshot.assetURLs
+            }
+            let missingURLs = await targetURLs.asyncFilter { !(await cache.contains($0)) }
+            guard (await download(missingURLs)).isComplete else {
+                return .failure(.requestFailed("펫 카탈로그 에셋 다운로드에 실패했습니다."))
+            }
             return .success(snapshot)
         }
 
@@ -163,15 +207,26 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
               allLevels.allSatisfy({ $0.assetURLs.count == 3 }) else {
             return .failure(.invalidResponse)
         }
-        let expectedAssetCount = candidate.assetURLs.count
-        let urlsToDownload = await candidate.assetURLs.asyncFilter {
+        let targetURLs: Set<URL>
+        if let requiredMainPet {
+            guard let required = requiredAssetURLs(
+                petType: requiredMainPet.type,
+                level: requiredMainPet.level,
+                snapshot: candidate
+            ) else { return .failure(.invalidResponse) }
+            targetURLs = required
+        } else {
+            targetURLs = candidate.assetURLs
+        }
+        let expectedAssetCount = targetURLs.count
+        let urlsToDownload = await targetURLs.asyncFilter {
             let isNewURL = !oldSnapshot.assetURLs.contains($0)
             if isNewURL { return true }
             let isCached = await cache.contains($0)
             return !isCached
         }
         let batch = await download(urlsToDownload)
-        let alreadyCachedCount = candidate.assetURLs.count - urlsToDownload.count
+        let alreadyCachedCount = targetURLs.count - urlsToDownload.count
         guard batch.isComplete,
               alreadyCachedCount + batch.cacheHits.count + batch.downloaded.count == expectedAssetCount else {
             return .failure(.requestFailed("펫 카탈로그 에셋 다운로드에 실패했습니다."))
@@ -187,6 +242,17 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
         generation &+= 1
         await publish(candidate)
         return .success(candidate)
+    }
+
+    private func requiredAssetURLs(
+        petType: String,
+        level: Int,
+        snapshot: PetCatalogSnapshot
+    ) -> Set<URL>? {
+        let presentation = PetPresentation.resolve(petType: petType, petLevel: level, snapshot: snapshot)
+        guard let selectedLevel = presentation.level,
+              selectedLevel.assetURLs.count == 3 else { return nil }
+        return selectedLevel.assetURLs
     }
 
     private func download(_ urls: Set<URL>) async -> PetAssetBatchResult {

--- a/DDanDDan/Repository/PetCatalogRepository.swift
+++ b/DDanDDan/Repository/PetCatalogRepository.swift
@@ -101,7 +101,7 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
         if !local.pets.isEmpty {
             let presentation = PetPresentation.resolve(petType: petType, petLevel: level, snapshot: local)
             guard let selectedLevel = presentation.level else {
-                return .failure(.requestFailed("메인 펫 카탈로그를 찾을 수 없습니다."))
+                return await sync()
             }
             let requiredURLs = selectedLevel.assetURLs
             guard requiredURLs.count == 3 else {
@@ -158,11 +158,12 @@ public actor PetCatalogRepository: PetCatalogRepositoryProtocol {
         guard !candidate.pets.isEmpty else {
             return .failure(.invalidResponse)
         }
-        let expectedAssetCount = catalog.pets.reduce(0) { $0 + ($1.levels.count * 3) }
-        guard expectedAssetCount > 0,
-              candidate.assetURLs.count == expectedAssetCount else {
+        let allLevels = catalog.pets.flatMap(\.levels)
+        guard !allLevels.isEmpty,
+              allLevels.allSatisfy({ $0.assetURLs.count == 3 }) else {
             return .failure(.invalidResponse)
         }
+        let expectedAssetCount = candidate.assetURLs.count
         let urlsToDownload = await candidate.assetURLs.asyncFilter {
             let isNewURL = !oldSnapshot.assetURLs.contains($0)
             if isNewURL { return true }

--- a/DDanDDan/Repository/SignUpRepository.swift
+++ b/DDanDDan/Repository/SignUpRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol SignUpRepositoryProtocol {
     func update(name: String?, purposeCalorie: Int?) async -> Result<UserData, NetworkError>
-    func getKakaoToken() -> String?
+    @MainActor func getLoginCredential() -> LoginCredential?
     func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError>
     func addPet(petType: String) async -> Result<Pet, NetworkError>
     func setMainPet(petID: String) async -> Result<MainPet, NetworkError>
@@ -31,8 +31,8 @@ public struct SignUpRepository: SignUpRepositoryProtocol {
     }
     
     @MainActor
-    public func getKakaoToken() -> String? {
-        return UserManager.shared.kakaoToken
+    func getLoginCredential() -> LoginCredential? {
+        UserManager.shared.loginCredential
     }
     
     public func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError> {

--- a/DDanDDan/Repository/SignUpRepository.swift
+++ b/DDanDDan/Repository/SignUpRepository.swift
@@ -11,7 +11,7 @@ protocol SignUpRepositoryProtocol {
     func update(name: String?, purposeCalorie: Int?) async -> Result<UserData, NetworkError>
     func getKakaoToken() -> String?
     func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError>
-    func addPet(petType: PetType) async -> Result<Pet, NetworkError>
+    func addPet(petType: String) async -> Result<Pet, NetworkError>
     func setMainPet(petID: String) async -> Result<MainPet, NetworkError>
 }
 
@@ -40,7 +40,7 @@ public struct SignUpRepository: SignUpRepositoryProtocol {
         return await authNetwork.login(token: token, tokenType: tokenType, deviceToken: deviceToken)
     }
     
-    public func addPet(petType: PetType) async -> Result<Pet, NetworkError> {
+    public func addPet(petType: String) async -> Result<Pet, NetworkError> {
         guard let accessToken = await UserManager.shared.accessToken else { return .failure(.requestFailed("Access Token Nil"))}
         return await petsNetwork.addPet(accessToken: accessToken, petType: petType)
     }

--- a/DDanDDan/Util/PetAssetCache.swift
+++ b/DDanDDan/Util/PetAssetCache.swift
@@ -53,8 +53,12 @@ public actor PetAssetCache: PetAssetCaching {
     }
 
     public func data(for url: URL) -> Data? {
-        guard let local = localURL(for: url) else { return nil }
-        return try? Data(contentsOf: local)
+        let local = fileURL(for: url)
+        guard let data = try? Data(contentsOf: local), Self.isValid(data, for: url) else {
+            try? FileManager.default.removeItem(at: local)
+            return nil
+        }
+        return data
     }
 
     public func download(_ url: URL) async -> URL? {

--- a/DDanDDan/Util/PetAssetCache.swift
+++ b/DDanDDan/Util/PetAssetCache.swift
@@ -5,118 +5,110 @@
 //  Created by mark.dd on 2026-05-12.
 //
 
-import Foundation
-import UIKit
 import CryptoKit
-// TODO: SVGKit SPM 추가 후 decode() 및 import 활성화 — 02_implementer_changes.md [B1] 참조.
-// import SVGKit
+import Foundation
 
-/// 펫 이미지(SVG/PNG/JPEG) 메모리 + 디스크 캐시.
-/// App Group `group.com.DdanDdan` 컨테이너 `pet-assets/` 디렉토리에 sha256 hex 파일명으로 저장한다.
-public actor PetAssetCache {
+public protocol PetAssetCaching: Sendable {
+    func contains(_ url: URL) async -> Bool
+    func localURL(for url: URL) async -> URL?
+    func data(for url: URL) async -> Data?
+    func download(_ url: URL) async -> URL?
+    func invalidate(_ url: URL) async
+}
+
+/// SVG/JSON을 해석하지 않고 원본 Data 그대로 저장하는 URL 기반 디스크 캐시.
+public actor PetAssetCache: PetAssetCaching {
     public static let shared = PetAssetCache(appGroup: "group.com.DdanDdan")
 
-    private let memory = NSCache<NSString, UIImage>()
     private let diskRoot: URL
-    private var inflight: [URL: Task<UIImage?, Never>] = [:]
+    private let session: URLSession
+    private var inflight: [URL: Task<URL?, Never>] = [:]
 
-    public init(appGroup: String) {
+    public init(appGroup: String, session: URLSession = .shared, diskRoot: URL? = nil) {
         let fm = FileManager.default
-        let baseURL: URL
-        if let containerURL = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
-            baseURL = containerURL.appendingPathComponent("pet-assets", isDirectory: true)
+        if let diskRoot {
+            self.diskRoot = diskRoot
+        } else if let container = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+            self.diskRoot = container.appendingPathComponent("PetCatalog/Assets", isDirectory: true)
         } else {
-            // App Group 컨테이너 접근 실패 시 안전 폴백 — crash 금지.
-            // 임시 디렉토리는 OS가 정리할 수 있으나, 적어도 컴파일/런타임은 통과.
-            // 운영 가시성을 위해 로그를 남긴다 — 타겟 간 캐시 공유가 깨진 신호.
-            print("⚠️ PetAssetCache: App Group '\(appGroup)' container missing — fallback to temporaryDirectory")
-            baseURL = fm.temporaryDirectory.appendingPathComponent("pet-assets", isDirectory: true)
+            let support = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            self.diskRoot = support.appendingPathComponent("DDanDDan/PetCatalog/Assets", isDirectory: true)
         }
-        self.diskRoot = baseURL
-        try? fm.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        self.session = session
+        try? fm.createDirectory(at: self.diskRoot, withIntermediateDirectories: true)
     }
 
-    /// 단일 URL에 대한 이미지 획득. 메모리 → 디스크 → 네트워크 순서.
-    public func image(for url: URL) async -> UIImage? {
-        // 1) 메모리 hit
-        if let cached = memory.object(forKey: url.absoluteString as NSString) {
-            return cached
+    public func contains(_ url: URL) -> Bool {
+        let local = fileURL(for: url)
+        guard let data = try? Data(contentsOf: local), Self.isValid(data, for: url) else {
+            try? FileManager.default.removeItem(at: local)
+            return false
         }
+        return true
+    }
 
-        // 2) 동일 URL inflight 공유 (dedup)
-        if let task = inflight[url] {
-            return await task.value
-        }
+    public func localURL(for url: URL) -> URL? {
+        let local = fileURL(for: url)
+        return contains(url) ? local : nil
+    }
 
-        // 3) 새 Task 등록. actor self 캡처 피하기 위해 stored property만 캡처.
-        let diskRoot = self.diskRoot
-        let memory = self.memory
-        let task = Task<UIImage?, Never> {
-            let filename = Self.sha256Hex(url.absoluteString)
-            let diskURL = diskRoot.appendingPathComponent(filename)
+    public func data(for url: URL) -> Data? {
+        guard let local = localURL(for: url) else { return nil }
+        return try? Data(contentsOf: local)
+    }
 
-            // 3-a) 디스크 hit
-            if let data = try? Data(contentsOf: diskURL), let img = Self.decode(data: data) {
-                memory.setObject(img, forKey: url.absoluteString as NSString)
-                return img
-            }
+    public func download(_ url: URL) async -> URL? {
+        if let local = localURL(for: url) { return local }
+        if let task = inflight[url] { return await task.value }
 
-            // 3-b) 네트워크 fetch → 디스크 write → 메모리 write
-            guard let (data, _) = try? await URLSession.shared.data(from: url),
-                  let img = Self.decode(data: data) else {
+        let local = fileURL(for: url)
+        let session = self.session
+        let task = Task<URL?, Never> {
+            guard !Task.isCancelled,
+                  let (data, response) = try? await session.data(from: url),
+                  let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode),
+                  Self.isValid(data, for: url) else { return nil }
+            do {
+                try data.write(to: local, options: .atomic)
+                return local
+            } catch {
                 return nil
             }
-            try? data.write(to: diskURL, options: .atomic)
-            memory.setObject(img, forKey: url.absoluteString as NSString)
-            return img
         }
-
         inflight[url] = task
         let result = await task.value
         inflight[url] = nil
         return result
     }
 
-    /// 다수 URL 사전 적재. 결과는 버리고 캐시에만 채운다.
-    public func prefetch(urls: [URL]) async {
+    public func invalidate(_ url: URL) {
+        try? FileManager.default.removeItem(at: fileURL(for: url))
+    }
+
+    public func prefetch(_ urls: Set<URL>) async {
         await withTaskGroup(of: Void.self) { group in
             for url in urls {
-                group.addTask { [weak self] in
-                    _ = await self?.image(for: url)
-                }
+                group.addTask { [weak self] in _ = await self?.download(url) }
             }
         }
     }
 
-    /// 메모리 + 디스크 캐시 전체 비우기. 진행 중 다운로드 Task도 함께 cancel하여
-    /// clear 직후 inflight 완료분이 캐시를 재오염시키는 것을 막는다.
-    public func clear() async {
-        for (_, task) in inflight {
-            task.cancel()
-        }
-        inflight.removeAll()
-        memory.removeAllObjects()
-        let fm = FileManager.default
-        if let items = try? fm.contentsOfDirectory(at: diskRoot, includingPropertiesForKeys: nil) {
-            for item in items {
-                try? fm.removeItem(at: item)
-            }
-        }
+    private func fileURL(for url: URL) -> URL {
+        let digest = SHA256.hash(data: Data(url.absoluteString.utf8))
+            .map { String(format: "%02x", $0) }.joined()
+        let ext = url.pathExtension.isEmpty ? "asset" : url.pathExtension.lowercased()
+        return diskRoot.appendingPathComponent("\(digest).\(ext)")
     }
 
-    // MARK: - Helpers
-
-    /// SVG 우선 → UIImage 폴백. 현재 SVGKit 미등록으로 UIImage 폴백만 동작.
-    private static func decode(data: Data) -> UIImage? {
-        // TODO: SVGKit SPM 추가 후 아래 블록 활성화.
-        // if let svg = SVGKImage(data: data), let img = svg.uiImage {
-        //     return img
-        // }
-        return UIImage(data: data)
-    }
-
-    private static func sha256Hex(_ string: String) -> String {
-        let digest = SHA256.hash(data: Data(string.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
+    private static func isValid(_ data: Data, for url: URL) -> Bool {
+        guard !data.isEmpty else { return false }
+        switch url.pathExtension.lowercased() {
+        case "json": return (try? JSONSerialization.jsonObject(with: data)) != nil
+        case "svg":
+            guard let value = String(data: data, encoding: .utf8)?.lowercased() else { return false }
+            return value.contains("<svg") && value.contains("</svg>")
+        default: return false
+        }
     }
 }

--- a/DDanDDan/Util/PetCatalogRevisionStore.swift
+++ b/DDanDDan/Util/PetCatalogRevisionStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public protocol PetCatalogRevisionProviding: Sendable {
+    var currentRevision: String { get }
+}
+
+public protocol PetCatalogRevisionStoring: PetCatalogRevisionProviding {
+    func saveRevision(_ revision: String)
+}
+
+public final class PetCatalogRevisionStore: PetCatalogRevisionStoring, @unchecked Sendable {
+    public static let shared = PetCatalogRevisionStore()
+    public static let epochRevision = "1970-01-01T00:00:00Z"
+
+    private let defaults: UserDefaults
+    private let key: String
+    private let lock = NSLock()
+
+    public init(defaults: UserDefaults = .standard, key: String = "petCatalogRevision") {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    public var currentRevision: String {
+        lock.withLock { defaults.string(forKey: key) ?? Self.epochRevision }
+    }
+
+    public func saveRevision(_ revision: String) {
+        lock.withLock { defaults.set(revision, forKey: key) }
+    }
+}

--- a/DDanDDan/Util/PetCatalogStorage.swift
+++ b/DDanDDan/Util/PetCatalogStorage.swift
@@ -1,0 +1,55 @@
+//
+//  PetCatalogStorage.swift
+//  DDanDDan
+//
+//  Created by Codex on 2026-07-01.
+//
+
+import Foundation
+
+public protocol PetCatalogStoring: Sendable {
+    func load() async -> PetCatalogResponse?
+    func save(_ catalog: PetCatalogResponse) async throws
+}
+
+public actor PetCatalogStorage: PetCatalogStoring {
+    private let fileURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let revisionStore: any PetCatalogRevisionStoring
+
+    public init(
+        appGroup: String = "group.com.DdanDdan",
+        fileURL: URL? = nil,
+        revisionStore: any PetCatalogRevisionStoring = PetCatalogRevisionStore.shared
+    ) {
+        self.revisionStore = revisionStore
+        if let fileURL {
+            self.fileURL = fileURL
+            return
+        }
+        let fm = FileManager.default
+        let root: URL
+        if let container = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+            root = container.appendingPathComponent("PetCatalog", isDirectory: true)
+        } else {
+            let support = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            root = support.appendingPathComponent("DDanDDan/PetCatalog", isDirectory: true)
+        }
+        try? fm.createDirectory(at: root, withIntermediateDirectories: true)
+        self.fileURL = root.appendingPathComponent("catalog.json")
+    }
+
+    public func load() -> PetCatalogResponse? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        guard let catalog = try? decoder.decode(PetCatalogResponse.self, from: data) else { return nil }
+        revisionStore.saveRevision(catalog.revision)
+        return catalog
+    }
+
+    public func save(_ catalog: PetCatalogResponse) throws {
+        let data = try encoder.encode(catalog)
+        try data.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+        revisionStore.saveRevision(catalog.revision)
+    }
+}

--- a/DDanDDan/Util/UserManager.swift
+++ b/DDanDDan/Util/UserManager.swift
@@ -7,12 +7,18 @@
 
 import Foundation
 
+struct LoginCredential: Equatable, Sendable {
+    let token: String
+    let tokenType: String
+}
+
 actor UserManager: ObservableObject {
     static let shared = UserManager()
     
     @MainActor @Published var accessToken: String? = UserDefaultValue.accessToken
     @MainActor public var kakaoToken: String?
     @MainActor public var appleToken: String?
+    @MainActor public var loginCredential: LoginCredential?
     @MainActor public var coordinator: AppCoordinator?
     
     private var refreshToken: String? = UserDefaultValue.refreshToken
@@ -54,6 +60,9 @@ actor UserManager: ObservableObject {
         await PetArchiveCache.shared.invalidate()
         await MainActor.run {
             accessToken = nil
+            kakaoToken = nil
+            appleToken = nil
+            loginCredential = nil
             UserDefaultValue.accessToken = nil
             UserDefaultValue.refreshToken = nil
             UserDefaultValue.userId = ""

--- a/DDanDDan/Util/WatchConnectivityManager.swift
+++ b/DDanDDan/Util/WatchConnectivityManager.swift
@@ -7,10 +7,17 @@
 
 import WatchConnectivity
 import SwiftUI
+import OSLog
 
 /// WatchConnectivity 관리하는 클래스, iOS - Watch 간 데이터 통신 담당
 final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
     static let shared = WatchConnectivityManager()
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "DDanDDan",
+        category: "WatchConnectivity"
+    )
+    @MainActor private var pendingPetMetadata: WatchPetSyncMetadata?
+    @MainActor private var pendingPetFileURL: URL?
     
     // MARK: - Init
     
@@ -49,6 +56,58 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
             print("WCSession is not activated")
         }
     }
+
+    /// 현재 메인 펫 상태와 서버 카탈로그 SVG를 Watch에 동기화한다.
+    /// 메타데이터는 최신 상태만 유지하고, SVG는 큰 데이터 전송에 적합한 transferFile을 사용한다.
+    func syncPet(
+        purposeKcal: Int,
+        petType: String,
+        level: Int,
+        presentation: PetPresentation
+    ) async {
+        let imageURL = presentation.level?.imageURL
+        let identity = [
+            PetCatalogSnapshot.canonicalType(petType),
+            String(level),
+            imageURL?.absoluteString ?? "placeholder"
+        ].joined(separator: "|")
+        let metadata = WatchPetSyncMetadata(
+            purposeKcal: purposeKcal,
+            petType: petType,
+            level: level,
+            colorCode: presentation.colorCode ?? "#D0DAE4",
+            assetIdentity: identity
+        )
+
+        let localURL: URL?
+        if let imageURL {
+            localURL = await PetAssetCache.shared.localURL(for: imageURL)
+        } else {
+            localURL = nil
+        }
+        await MainActor.run {
+            pendingPetMetadata = metadata
+            pendingPetFileURL = localURL
+            flushPendingPetSyncIfPossible()
+        }
+    }
+
+    @MainActor
+    private func flushPendingPetSyncIfPossible() {
+        let session = WCSession.default
+        guard session.activationState == .activated,
+              let metadata = pendingPetMetadata else { return }
+        do {
+            try session.updateApplicationContext(metadata.dictionary)
+            if let pendingPetFileURL {
+                session.transferFile(pendingPetFileURL, metadata: metadata.dictionary)
+            }
+            self.pendingPetMetadata = nil
+            self.pendingPetFileURL = nil
+        } catch {
+            Self.logger.error("Failed to update Watch context: \(error.localizedDescription, privacy: .public)")
+        }
+    }
     
     
     // MARK: - 필수 구현 메서드 및 Delegate 메서드
@@ -56,6 +115,11 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
     /// WCSessionDelegate 프로토콜 메서드 - 세션 활성화 완료 시 호출
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: (any Error)?) {
         print("WCSession activation completed with state: \(activationState)")
+        Task { @MainActor [weak self] in self?.flushPendingPetSyncIfPossible() }
+    }
+
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        Task { @MainActor [weak self] in self?.flushPendingPetSyncIfPossible() }
     }
     
     

--- a/DDanDDan/Util/WatchConnectivityManager.swift
+++ b/DDanDDan/Util/WatchConnectivityManager.swift
@@ -27,6 +27,7 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
     )
     @MainActor private var pendingPetMetadata: WatchPetSyncMetadata?
     @MainActor private var pendingPetFileURL: URL?
+    @MainActor private var lastTransferredAssetIdentity: String?
     
     // MARK: - Init
     
@@ -108,8 +109,10 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
               let metadata = pendingPetMetadata else { return }
         do {
             try session.updateApplicationContext(metadata.dictionary)
-            if let pendingPetFileURL {
+            if lastTransferredAssetIdentity != metadata.assetIdentity,
+               let pendingPetFileURL {
                 session.transferFile(pendingPetFileURL, metadata: metadata.dictionary)
+                lastTransferredAssetIdentity = metadata.assetIdentity
             }
             self.pendingPetMetadata = nil
             self.pendingPetFileURL = nil
@@ -129,6 +132,17 @@ final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDeleg
 
     func sessionWatchStateDidChange(_ session: WCSession) {
         Task { @MainActor [weak self] in self?.flushPendingPetSyncIfPossible() }
+    }
+
+    func session(_ session: WCSession, didFinish fileTransfer: WCSessionFileTransfer, error: (any Error)?) {
+        guard error != nil,
+              let identity = fileTransfer.file.metadata
+                .flatMap(WatchPetSyncMetadata.init(dictionary:))?
+                .assetIdentity else { return }
+        Task { @MainActor [weak self] in
+            guard self?.lastTransferredAssetIdentity == identity else { return }
+            self?.lastTransferredAssetIdentity = nil
+        }
     }
     
     

--- a/DDanDDan/Util/WatchConnectivityManager.swift
+++ b/DDanDDan/Util/WatchConnectivityManager.swift
@@ -9,8 +9,17 @@ import WatchConnectivity
 import SwiftUI
 import OSLog
 
+protocol WatchPetSyncing: Sendable {
+    func syncPet(
+        purposeKcal: Int,
+        petType: String,
+        level: Int,
+        presentation: PetPresentation
+    ) async
+}
+
 /// WatchConnectivity 관리하는 클래스, iOS - Watch 간 데이터 통신 담당
-final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
+final class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate, WatchPetSyncing, @unchecked Sendable {
     static let shared = WatchConnectivityManager()
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "DDanDDan",

--- a/DDanDDanTests/PetCatalogHeaderTests.swift
+++ b/DDanDDanTests/PetCatalogHeaderTests.swift
@@ -1,0 +1,183 @@
+import Alamofire
+import XCTest
+@testable import DDanDDan
+
+final class PetCatalogHeaderTests: XCTestCase {
+    override func tearDown() {
+        RequestCaptureURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testAuthNetworkLoginAndReissueApplyExactHeaderPolicy() async {
+        let expectation = expectation(description: "requests")
+        expectation.expectedFulfillmentCount = 2
+        let lock = NSLock()
+        var captured: [URLRequest] = []
+        RequestCaptureURLProtocol.handler = { request in
+            lock.withLock { captured.append(request) }
+            expectation.fulfill()
+            return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, Data())
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RequestCaptureURLProtocol.self]
+        let manager = NetworkManager(
+            withInterceptor: false,
+            revisionProvider: RevisionSpy("stored-revision"),
+            responseHeaderHandler: NoopHeaderHandler(),
+            configuration: configuration,
+            baseURL: "https://example.com"
+        )
+        let network = AuthNetwork(manager: manager)
+        async let login = network.login(token: "token", tokenType: "KAKAO", deviceToken: nil)
+        async let reissue = network.tokenReissue(refreshToken: "refresh")
+        _ = await (login, reissue)
+        await fulfillment(of: [expectation], timeout: 2)
+
+        let requests = lock.withLock { captured }
+        let loginRequest = requests.first { $0.url?.path == "/v1/auth/login" }
+        let reissueRequest = requests.first { $0.url?.path == "/v1/auth/reissue" }
+        XCTAssertNil(loginRequest?.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader))
+        XCTAssertEqual(reissueRequest?.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader), "stored-revision")
+    }
+
+    func testLoginRemovesRevisionHeader() async throws {
+        let interceptor = PetCatalogHeaderInterceptor(revisionProvider: RevisionSpy("r1"))
+        var request = URLRequest(url: URL(string: "https://example.com/v1/auth/login")!)
+        request.setValue("caller", forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader)
+        let adapted = try await adapt(request, using: interceptor)
+        XCTAssertNil(adapted.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader))
+    }
+
+    func testGeneralAndLoginExtraRequestsIncludeStoredRevision() async throws {
+        let interceptor = PetCatalogHeaderInterceptor(revisionProvider: RevisionSpy("2026-07-02T01:02:03Z"))
+        for path in ["/v1/pets/me", "/v1/auth/login-extra"] {
+            let request = URLRequest(url: URL(string: "https://example.com\(path)")!)
+            let adapted = try await adapt(request, using: interceptor)
+            XCTAssertEqual(adapted.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader), "2026-07-02T01:02:03Z")
+        }
+    }
+
+    func testReissueIncludesRevision() async throws {
+        let interceptor = PetCatalogHeaderInterceptor(revisionProvider: RevisionSpy("revision"))
+        let request = URLRequest(url: URL(string: "https://example.com/v1/auth/reissue")!)
+        let adapted = try await adapt(request, using: interceptor)
+        XCTAssertEqual(adapted.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader), "revision")
+    }
+
+    func testMissingRevisionUsesEpoch() async throws {
+        let suite = "revision-tests-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = PetCatalogRevisionStore(defaults: defaults)
+        let request = URLRequest(url: URL(string: "https://example.com/v1/users/me")!)
+        let adapted = try await adapt(request, using: PetCatalogHeaderInterceptor(revisionProvider: store))
+        XCTAssertEqual(adapted.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader), PetCatalogRevisionStore.epochRevision)
+    }
+
+    func testFalseAndMissingResponseHeadersDoNotRefresh() async {
+        let coordinator = RefreshSpy()
+        let handler = PetCatalogResponseHeaderHandler(coordinator: coordinator)
+        await handler.handle(response: response(headers: ["x-pEt-cAtAlOg-doWnLoAd-rEqUiReD": "false"]), requestURL: url("/v1/pets/me"))
+        await handler.handle(response: response(headers: [:]), requestURL: url("/v1/pets/me"))
+        let count = await coordinator.count
+        XCTAssertEqual(count, 0)
+    }
+
+    func testTrueResponseHeaderRefreshesCaseInsensitively() async {
+        let coordinator = RefreshSpy()
+        let handler = PetCatalogResponseHeaderHandler(coordinator: coordinator)
+        await handler.handle(response: response(headers: ["x-pEt-cAtAlOg-doWnLoAd-rEqUiReD": " TrUe "]), requestURL: url("/v1/pets/me"))
+        let count = await coordinator.count
+        XCTAssertEqual(count, 1)
+    }
+
+    func testCatalogTrueDoesNotRecursivelyRefresh() async {
+        let coordinator = RefreshSpy()
+        let handler = PetCatalogResponseHeaderHandler(coordinator: coordinator)
+        await handler.handle(response: response(headers: [PetCatalogResponseHeaderHandler.downloadRequiredHeader: "true"]), requestURL: url("/v1/pets/catalog"))
+        let count = await coordinator.count
+        XCTAssertEqual(count, 0)
+    }
+
+    func testConcurrentTrueResponsesRefreshOnlyOnce() async throws {
+        let counter = Counter()
+        let coordinator = PetCatalogRefreshCoordinator {
+            await counter.started()
+            try? await Task.sleep(nanoseconds: 150_000_000)
+        }
+        let handler = PetCatalogResponseHeaderHandler(coordinator: coordinator)
+        let trueResponse = response(headers: [PetCatalogResponseHeaderHandler.downloadRequiredHeader: "true"])
+        let requestURL = url("/v1/pets/me")
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask { await handler.handle(response: trueResponse, requestURL: requestURL) }
+            }
+        }
+        try await Task.sleep(nanoseconds: 250_000_000)
+        let firstCount = await counter.count
+        XCTAssertEqual(firstCount, 1)
+        await handler.handle(response: trueResponse, requestURL: requestURL)
+        try await Task.sleep(nanoseconds: 250_000_000)
+        let secondCount = await counter.count
+        XCTAssertEqual(secondCount, 2)
+    }
+
+    func testStorageCommitUpdatesSubsequentHeaderRevisionVerbatim() async throws {
+        let suite = "revision-tests-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let revisionStore = PetCatalogRevisionStore(defaults: defaults)
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let storage = PetCatalogStorage(fileURL: file, revisionStore: revisionStore)
+        let revision = "2026-07-02T10:11:12.123+09:00"
+        try await storage.save(.init(revision: revision, pets: []))
+
+        let request = URLRequest(url: url("/v1/pets/me"))
+        let adapted = try await adapt(request, using: PetCatalogHeaderInterceptor(revisionProvider: revisionStore))
+        XCTAssertEqual(adapted.value(forHTTPHeaderField: PetCatalogHeaderInterceptor.revisionHeader), revision)
+    }
+
+    private func adapt(_ request: URLRequest, using interceptor: PetCatalogHeaderInterceptor) async throws -> URLRequest {
+        try await withCheckedThrowingContinuation { continuation in
+            interceptor.adapt(request, for: Session()) { continuation.resume(with: $0) }
+        }
+    }
+
+    private func url(_ path: String) -> URL { URL(string: "https://example.com\(path)")! }
+    private func response(headers: [String: String]) -> HTTPURLResponse {
+        HTTPURLResponse(url: url("/v1/pets/me"), statusCode: 200, httpVersion: nil, headerFields: headers)!
+    }
+}
+
+private struct RevisionSpy: PetCatalogRevisionProviding {
+    let currentRevision: String
+    init(_ value: String) { currentRevision = value }
+}
+
+private actor RefreshSpy: PetCatalogRefreshCoordinating {
+    private(set) var count = 0
+    func requestRefresh() { count += 1 }
+}
+
+private actor Counter {
+    private(set) var count = 0
+    func started() { count += 1 }
+}
+
+private struct NoopHeaderHandler: PetCatalogResponseHeaderHandling {
+    func handle(response: HTTPURLResponse, requestURL: URL) async {}
+}
+
+private final class RequestCaptureURLProtocol: URLProtocol, @unchecked Sendable {
+    static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        guard let handler = Self.handler else { return }
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}

--- a/DDanDDanTests/PetCatalogHeaderTests.swift
+++ b/DDanDDanTests/PetCatalogHeaderTests.swift
@@ -170,8 +170,8 @@ private struct NoopHeaderHandler: PetCatalogResponseHeaderHandling {
 
 private final class RequestCaptureURLProtocol: URLProtocol, @unchecked Sendable {
     static var handler: ((URLRequest) -> (HTTPURLResponse, Data))?
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
     override func startLoading() {
         guard let handler = Self.handler else { return }
         let (response, data) = handler(request)

--- a/DDanDDanTests/PetCatalogHeaderTests.swift
+++ b/DDanDDanTests/PetCatalogHeaderTests.swift
@@ -99,6 +99,54 @@ final class PetCatalogHeaderTests: XCTestCase {
         XCTAssertEqual(count, 0)
     }
 
+    func testReissueTrueDoesNotRefreshCatalog() async {
+        let coordinator = RefreshSpy()
+        let handler = PetCatalogResponseHeaderHandler(coordinator: coordinator)
+        await handler.handle(
+            response: response(headers: [PetCatalogResponseHeaderHandler.downloadRequiredHeader: "true"]),
+            requestURL: url("/v1/auth/reissue")
+        )
+        let count = await coordinator.count
+        XCTAssertEqual(count, 0)
+    }
+
+    func testFailedRefreshIsSharedWithLate401ForSameAccessToken() async {
+        let originalAccessToken = UserDefaultValue.accessToken
+        let originalRefreshToken = UserDefaultValue.refreshToken
+        defer {
+            UserDefaultValue.accessToken = originalAccessToken
+            UserDefaultValue.refreshToken = originalRefreshToken
+        }
+        let counter = Counter()
+        let manager = TokenRefreshManager(
+            reissue: { _ in
+                await counter.started()
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                return .failure(.requestFailed("expired refresh token"))
+            },
+            applyReissue: { _ in },
+            logout: {}
+        )
+        UserDefaultValue.accessToken = "expired-access"
+        UserDefaultValue.refreshToken = "expired-refresh"
+
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    await manager.refresh(failedRequestAuthorization: "Bearer expired-access")
+                }
+            }
+            for await result in group {
+                XCTAssertFalse(result)
+            }
+        }
+        let lateResult = await manager.refresh(failedRequestAuthorization: "Bearer expired-access")
+        let count = await counter.count
+
+        XCTAssertFalse(lateResult)
+        XCTAssertEqual(count, 1)
+    }
+
     func testConcurrentTrueResponsesRefreshOnlyOnce() async throws {
         let counter = Counter()
         let coordinator = PetCatalogRefreshCoordinator {

--- a/DDanDDanTests/PetCatalogTests.swift
+++ b/DDanDDanTests/PetCatalogTests.swift
@@ -678,6 +678,26 @@ final class PetCatalogTests: XCTestCase {
     }
 
     @MainActor
+    func testSplashFetchesUserAndMainPetConcurrently() async {
+        let coordinator = AppCoordinator()
+        let repository = ConcurrentBootstrapHomeRepository()
+        let snapshot = PetCatalogSnapshot(revision: "ready", pets: [item(type: "CAT", levels: [1])])
+        let viewModel = SplashViewModel(
+            coordinator: coordinator,
+            homeRepository: repository,
+            catalogRepository: SignUpCatalogStub(
+                response: .init(revision: snapshot.revision, pets: snapshot.pets)
+            )
+        )
+
+        await viewModel.performInitialSetup()
+
+        let maximumConcurrentRequests = await repository.maximumConcurrentRequests
+        XCTAssertEqual(maximumConcurrentRequests, 2)
+        XCTAssertEqual(coordinator.rootView, .mainTab)
+    }
+
+    @MainActor
     func testFriendCardBackgroundResolverUsesPublishedCatalogColor() async {
         let store = PetCatalogStore()
         let before = FriendCardCatalogResolver.presentation(petType: "CAT", petLevel: 1, snapshot: store.snapshot)
@@ -761,6 +781,38 @@ private struct SplashHomeRepositoryStub: HomeRepositoryProtocol {
     func getMainPetInfo() async -> Result<MainPet, NetworkError> {
         .success(.init(mainPet: .init(id: "pet", type: "CAT", level: 1, expPercent: 0)))
     }
+    func getPetArchive() async -> Result<PetArchiveModel, NetworkError> { .failure(.requestFailed("unused")) }
+    func getSpecificPet(petId: String) async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func updateMainPet(petId: String) async -> Result<MainPet, NetworkError> { .failure(.requestFailed("unused")) }
+    func feedPet(petId: String) async -> Result<UserPetData, NetworkError> { .failure(.requestFailed("unused")) }
+    func playPet(petId: String) async -> Result<UserPetData, NetworkError> { .failure(.requestFailed("unused")) }
+    func addNewPet(petType: String) async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func addNewRandomPet() async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func addNewGachaRandomPet() async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func updateDailyKcal(calorie: Int) async -> Result<DailyUserData, NetworkError> { .failure(.requestFailed("unused")) }
+}
+
+private actor ConcurrentBootstrapHomeRepository: HomeRepositoryProtocol {
+    private var activeRequests = 0
+    private(set) var maximumConcurrentRequests = 0
+
+    func getUserInfo() async -> Result<HomeUserInfo, NetworkError> {
+        await recordRequest()
+        return .success(.init(id: "user", purposeCalorie: 100, foodQuantity: 1, toyQuantity: 1, tickets: 0))
+    }
+
+    func getMainPetInfo() async -> Result<MainPet, NetworkError> {
+        await recordRequest()
+        return .success(.init(mainPet: .init(id: "pet", type: "CAT", level: 1, expPercent: 0)))
+    }
+
+    private func recordRequest() async {
+        activeRequests += 1
+        maximumConcurrentRequests = max(maximumConcurrentRequests, activeRequests)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        activeRequests -= 1
+    }
+
     func getPetArchive() async -> Result<PetArchiveModel, NetworkError> { .failure(.requestFailed("unused")) }
     func getSpecificPet(petId: String) async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
     func updateMainPet(petId: String) async -> Result<MainPet, NetworkError> { .failure(.requestFailed("unused")) }

--- a/DDanDDanTests/PetCatalogTests.swift
+++ b/DDanDDanTests/PetCatalogTests.swift
@@ -1,0 +1,621 @@
+import Combine
+import XCTest
+@testable import DDanDDan
+
+final class PetCatalogTests: XCTestCase {
+    func testFreshCatalogWaitsForEveryAssetBeforeSave() async {
+        let response = PetCatalogResponse(revision: "fresh", pets: [item(type: "CAT", levels: [1, 2])])
+        let storage = StorageSpy(value: nil)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(response)), storage: storage, cache: cache)
+
+        let result = await repository.sync()
+
+        guard case .success = result else { return XCTFail("all assets should be ready") }
+        let saveCount = await storage.saveCount
+        let downloadCount = await cache.downloaded.count
+        XCTAssertEqual(saveCount, 1)
+        XCTAssertEqual(downloadCount, 6)
+    }
+
+    func testFreshCatalogAssetFailureBlocksSaveAndPublish() async {
+        let response = PetCatalogResponse(revision: "fresh", pets: [item(type: "CAT", levels: [1])])
+        let failedURL = URL(string: "https://a/1d.json")!
+        let storage = StorageSpy(value: nil)
+        let cache = CacheSpy(alwaysFail: [failedURL])
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(response)), storage: storage, cache: cache)
+
+        let result = await repository.sync()
+
+        guard case .failure = result else { return XCTFail("failure should block bootstrap") }
+        let saveCount = await storage.saveCount
+        let stored = await storage.load()
+        XCTAssertEqual(saveCount, 0)
+        XCTAssertNil(stored)
+    }
+
+    func testFreshCatalogMalformedAssetURLBlocksSave() async {
+        let malformedLevel = PetCatalogLevel(
+            level: 1,
+            imageUrl: "relative.svg",
+            lottieDefaultUrl: "https://a/default.json",
+            lottiePlayEatUrl: "https://a/play.json"
+        )
+        let response = PetCatalogResponse(
+            revision: "malformed",
+            pets: [.init(type: "CAT", name: "cat", colorCode: "#112233", displayOrder: 0, levels: [malformedLevel])]
+        )
+        let storage = StorageSpy(value: nil)
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(response)),
+            storage: storage,
+            cache: CacheSpy()
+        )
+
+        guard case .failure(.invalidResponse) = await repository.sync() else {
+            return XCTFail("malformed URL must invalidate the whole candidate")
+        }
+        let saveCount = await storage.saveCount
+        let stored = await storage.load()
+        XCTAssertEqual(saveCount, 0)
+        XCTAssertNil(stored)
+    }
+
+    func testRevisionAssetFailurePreservesStoredCatalog() async {
+        let old = PetCatalogResponse(revision: "old", pets: [item(type: "CAT", levels: [1], host: "old")])
+        let new = PetCatalogResponse(revision: "new", pets: [item(type: "CAT", levels: [1], host: "new")])
+        let storage = StorageSpy(value: old)
+        let cache = CacheSpy(alwaysFail: [URL(string: "https://new/1.svg")!])
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(new)), storage: storage, cache: cache)
+        _ = await repository.loadLocal()
+
+        guard case .failure = await repository.sync() else { return XCTFail("revision should not commit") }
+        let stored = await storage.load()
+        let saveCount = await storage.saveCount
+        XCTAssertEqual(stored?.revision, "old")
+        XCTAssertEqual(saveCount, 0)
+    }
+
+    func testCachedLaunchWaitsOnlyForSelectedMainPetAssets() async {
+        let local = PetCatalogResponse(revision: "local", pets: [
+            item(type: "CAT", levels: [1, 2]),
+            item(type: "DOG", levels: [1])
+        ])
+        let storage = StorageSpy(value: local)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .failure(.requestFailed("offline"))),
+            storage: storage,
+            cache: cache
+        )
+
+        guard case .success = await repository.prepareForMain(petType: "CAT", level: 2) else {
+            return XCTFail("selected level assets should be downloaded")
+        }
+        let downloaded = await cache.downloaded
+        XCTAssertEqual(downloaded, local.pets[0].levels[1].assetURLs)
+    }
+
+    @MainActor
+    func testStoreDoesNotPublishSameSnapshotTwice() {
+        let store = PetCatalogStore()
+        let snapshot = PetCatalogSnapshot(revision: "same", pets: [item(type: "CAT", levels: [1])])
+        var emissions = 0
+        let cancellable = store.$snapshot.dropFirst().sink { _ in emissions += 1 }
+        store.publish(snapshot)
+        store.publish(snapshot)
+        XCTAssertEqual(emissions, 1)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @MainActor
+    func testRemoteAssetStateKeepsReadyAWhileBLoadsAndRejectsStaleCommit() {
+        let state = RemotePetAssetLoadState()
+        XCTAssertTrue(state.begin(identity: "A"))
+        state.commit(svg: "<svg>A</svg>", identity: "A")
+        XCTAssertEqual(state.svg, "<svg>A</svg>")
+
+        XCTAssertTrue(state.begin(identity: "B"))
+        XCTAssertEqual(state.svg, "<svg>A</svg>", "ready A must remain visible while B loads")
+        state.commit(svg: "<svg>stale A</svg>", identity: "A")
+        XCTAssertEqual(state.svg, "<svg>A</svg>", "stale completion must not commit")
+        state.commit(svg: "<svg>B</svg>", identity: "B")
+        XCTAssertEqual(state.svg, "<svg>B</svg>")
+        XCTAssertEqual(state.readyIdentity, "B")
+    }
+
+    @MainActor
+    func testRemoteAssetStateKeepsReadyAWhenBTerminallyFails() {
+        let state = RemotePetAssetLoadState()
+        _ = state.begin(identity: "A")
+        state.commit(svg: "<svg>A</svg>", identity: "A")
+        _ = state.begin(identity: "B")
+
+        state.fail(identity: "B")
+
+        XCTAssertEqual(state.svg, "<svg>A</svg>")
+        XCTAssertEqual(state.readyIdentity, "A")
+        XCTAssertEqual(state.failedIdentity, "B")
+    }
+
+    func testDecodesContractWithoutRemovedFields() throws {
+        let data = Data(##"{"revision":"r1","pets":[{"type":"CAT","name":"고양이","colorCode":"#112233","displayOrder":1,"levels":[{"level":1,"imageUrl":"https://a/1.svg","lottieDefaultUrl":"https://a/d.json","lottiePlayEatUrl":"https://a/p.json"}]}]}"##.utf8)
+        let decoded = try JSONDecoder().decode(PetCatalogResponse.self, from: data)
+        XCTAssertEqual(decoded.revision, "r1")
+        XCTAssertEqual(decoded.pets.first?.levels.first?.level, 1)
+    }
+
+    func testJoinsByTypeAndSelectsHighestLevel() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [item(type: "NEW", levels: [5, 1, 3])])
+        XCTAssertEqual(PetPresentation.resolve(petType: "NEW", petLevel: 4, snapshot: snapshot).level?.level, 3)
+        XCTAssertEqual(PetPresentation.resolve(petType: "NEW", petLevel: 5, snapshot: snapshot).level?.level, 5)
+    }
+
+    func testLevelAboveFiveUsesLevelFive() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [item(type: "NEW", levels: [1, 5])])
+        XCTAssertEqual(PetPresentation.resolve(petType: "NEW", petLevel: 99, snapshot: snapshot).level?.level, 5)
+    }
+
+    func testSelectsEachLevelOneThroughFive() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [item(type: "CAT", levels: [1, 2, 3, 4, 5])])
+        for level in 1...5 {
+            XCTAssertEqual(PetPresentation.resolve(petType: "CAT", petLevel: level, snapshot: snapshot).level?.level, level)
+        }
+    }
+
+    func testRelativeAndMalformedURLsFallBack() {
+        let level = PetCatalogLevel(level: 1, imageUrl: "relative.svg", lottieDefaultUrl: "not-a-url", lottiePlayEatUrl: "ftp://a/p.json")
+        let catalog = PetCatalogItem(type: "BAD", name: "bad", colorCode: "#112233", displayOrder: 0, levels: [level])
+        let result = PetPresentation.resolve(petType: "BAD", petLevel: 1, snapshot: .init(revision: "1", pets: [catalog]))
+        XCTAssertTrue(result.usesPlaceholder)
+    }
+
+    func testInvalidCatalogFallsBack() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [item(type: "EMPTY", color: "oops", levels: [])])
+        XCTAssertTrue(PetPresentation.resolve(petType: "UNKNOWN", petLevel: 1, snapshot: snapshot).usesPlaceholder)
+        let invalid = PetPresentation.resolve(petType: "EMPTY", petLevel: 1, snapshot: snapshot)
+        XCTAssertNil(invalid.colorCode)
+        XCTAssertTrue(invalid.usesPlaceholder)
+    }
+
+    func testSameRevisionSkipsDownloadAndSave() async {
+        let response = PetCatalogResponse(revision: "same", pets: [item(type: "CAT", levels: [1])])
+        let storage = StorageSpy(value: response)
+        let cache = CacheSpy(existing: PetCatalogSnapshot(revision: response.revision, pets: response.pets).assetURLs)
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(response)), storage: storage, cache: cache)
+        _ = await repository.loadLocal()
+        _ = await repository.sync()
+        let saveCount = await storage.saveCount
+        let downloadCount = await cache.downloaded.count
+        XCTAssertEqual(saveCount, 0)
+        XCTAssertEqual(downloadCount, 0)
+    }
+
+    func testSameRevisionRetriesOnlyMissingFiles() async {
+        let response = PetCatalogResponse(revision: "same", pets: [item(type: "CAT", levels: [1])])
+        let storage = StorageSpy(value: response)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(response)), storage: storage, cache: cache)
+        _ = await repository.loadLocal()
+        _ = await repository.sync()
+        let count = await cache.downloaded.count
+        XCTAssertEqual(count, 3)
+    }
+
+    func testFailedDownloadIsRetriedOnNextSameRevisionSync() async {
+        let response = PetCatalogResponse(revision: "new", pets: [item(type: "CAT", levels: [1])])
+        let urls = PetCatalogSnapshot(revision: response.revision, pets: response.pets).assetURLs
+        let cache = CacheSpy(failOnce: urls)
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(response)), storage: StorageSpy(value: nil), cache: cache)
+        _ = await repository.sync()
+        _ = await repository.sync()
+        let attempts = await cache.attempts
+        XCTAssertTrue(attempts.values.allSatisfy { $0 == 2 })
+        XCTAssertEqual(attempts.count, 3)
+    }
+
+    func testRevisionChangeDownloadsOnlyChangedOrMissing() async {
+        let old = PetCatalogResponse(revision: "1", pets: [item(type: "CAT", levels: [1], host: "old")])
+        let new = PetCatalogResponse(revision: "2", pets: [item(type: "CAT", levels: [1], host: "new")])
+        let storage = StorageSpy(value: old)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(new)), storage: storage, cache: cache)
+        _ = await repository.loadLocal()
+        _ = await repository.sync()
+        let saveCount = await storage.saveCount
+        let downloadCount = await cache.downloaded.count
+        XCTAssertEqual(saveCount, 1)
+        XCTAssertEqual(downloadCount, 3)
+    }
+
+    func testRevisionChangeKeepsUnchangedAndDownloadsChangedPlusMissing() async {
+        let oldLevel = PetCatalogLevel(level: 1, imageUrl: "https://a/image.svg", lottieDefaultUrl: "https://a/old.json", lottiePlayEatUrl: "https://a/play.json")
+        let newLevel = PetCatalogLevel(level: 1, imageUrl: "https://a/image.svg", lottieDefaultUrl: "https://a/new.json", lottiePlayEatUrl: "https://a/play.json")
+        let old = PetCatalogResponse(revision: "1", pets: [.init(type: "CAT", name: "cat", colorCode: "#112233", displayOrder: 0, levels: [oldLevel])])
+        let new = PetCatalogResponse(revision: "2", pets: [.init(type: "CAT", name: "cat", colorCode: "#112233", displayOrder: 0, levels: [newLevel])])
+        let imageURL = URL(string: oldLevel.imageUrl)!
+        let cache = CacheSpy(existing: [imageURL])
+        let repository = PetCatalogRepository(network: NetworkStub(result: .success(new)), storage: StorageSpy(value: old), cache: cache)
+        _ = await repository.loadLocal()
+        _ = await repository.sync()
+        let downloaded = await cache.downloaded
+        XCTAssertEqual(downloaded, [URL(string: newLevel.lottieDefaultUrl)!, URL(string: newLevel.lottiePlayEatUrl)!])
+    }
+
+    func testNetworkFailureKeepsLocalCatalog() async {
+        let old = PetCatalogResponse(revision: "local", pets: [item(type: "CAT", levels: [1])])
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .failure(.requestFailed("offline"))),
+            storage: StorageSpy(value: old), cache: CacheSpy()
+        )
+        _ = await repository.loadLocal()
+        let result = await repository.sync()
+        if case .success = result { XCTFail("failure expected") }
+        let local = await repository.loadLocal()
+        XCTAssertEqual(local.revision, "local")
+    }
+
+    func testAtomicStorageRoundTrip() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storage = PetCatalogStorage(fileURL: directory.appendingPathComponent("catalog.json"))
+        let expected = PetCatalogResponse(revision: "r2", pets: [item(type: "CAT", levels: [1, 5])])
+        try await storage.save(expected)
+        let loaded = await storage.load()
+        XCTAssertEqual(loaded, expected)
+    }
+
+    func testConcurrentSyncIsSingleFlight() async {
+        let response = PetCatalogResponse(revision: "new", pets: [item(type: "CAT", levels: [1])])
+        let network = DelayedNetwork(response: response)
+        let repository = PetCatalogRepository(network: network, storage: StorageSpy(value: nil), cache: CacheSpy())
+        let revisions = await withTaskGroup(of: String?.self, returning: [String?].self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    guard case let .success(snapshot) = await repository.sync() else { return nil }
+                    return snapshot.revision
+                }
+            }
+            var values: [String?] = []
+            for await value in group { values.append(value) }
+            return values
+        }
+        let count = await network.callCount
+        XCTAssertEqual(count, 1)
+        XCTAssertEqual(revisions.count, 8)
+        XCTAssertTrue(revisions.allSatisfy { $0 == "new" })
+    }
+
+    func testOlderResponseCannotOverwriteNewerLocalGeneration() async {
+        let oldResponse = PetCatalogResponse(revision: "old-server", pets: [item(type: "OLD", levels: [1])])
+        let newerLocal = PetCatalogResponse(revision: "new-local", pets: [item(type: "NEW", levels: [1])])
+        let network = DelayedNetwork(response: oldResponse)
+        let storage = StorageSpy(value: nil)
+        let repository = PetCatalogRepository(network: network, storage: storage, cache: CacheSpy())
+        let syncTask = Task { await repository.sync() }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        await storage.set(newerLocal)
+        _ = await repository.loadLocal()
+        _ = await syncTask.value
+        let stored = await storage.load()
+        XCTAssertEqual(stored?.revision, "new-local")
+    }
+
+    func testFeedResponseAppliesLatestStateAndReselectsLevelAsset() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [item(type: "CAT", levels: [1, 2, 3, 4, 5])])
+        let state = HomePetInteractionReducer.reduce(
+            response: .init(petID: "pet-new", petType: "CAT", level: 4, expPercent: 12, foodQuantity: 7, toyQuantity: 8),
+            catalog: snapshot
+        )
+        XCTAssertEqual(state.petID, "pet-new")
+        XCTAssertEqual(state.petType, "CAT")
+        XCTAssertEqual(state.level, 4)
+        XCTAssertEqual(state.expPercent, 12)
+        XCTAssertEqual(state.foodQuantity, 7)
+        XCTAssertEqual(state.toyQuantity, 8)
+        XCTAssertEqual(state.presentation.level?.level, 4)
+        XCTAssertEqual(state.presentation.level?.imageUrl, "https://a/4.svg")
+    }
+
+    func testPlayResponseTypeAndLevelChangeSelectsNewCatalogAsset() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [
+            item(type: "CAT", levels: [1, 2]),
+            item(type: "NEW_TYPE", levels: [1, 5], host: "new")
+        ])
+        let state = HomePetInteractionReducer.reduce(
+            response: .init(petID: "changed", petType: "NEW_TYPE", level: 6, expPercent: 33, foodQuantity: 2, toyQuantity: 1),
+            catalog: snapshot
+        )
+        XCTAssertEqual(state.petID, "changed")
+        XCTAssertEqual(state.petType, "NEW_TYPE")
+        XCTAssertEqual(state.level, 6)
+        XCTAssertEqual(state.expPercent, 33)
+        XCTAssertEqual(state.foodQuantity, 2)
+        XCTAssertEqual(state.toyQuantity, 1)
+        XCTAssertEqual(state.presentation.level?.level, 5)
+        XCTAssertEqual(state.presentation.level?.imageUrl, "https://new/5.svg")
+    }
+
+    func testLoginBootstrapWithEmptyLocalWaitsForServerSnapshot() async {
+        let response = PetCatalogResponse(revision: "login-r1", pets: [item(type: "CAT", levels: [1])])
+        let cache = CacheSpy(existing: PetCatalogSnapshot(revision: response.revision, pets: response.pets).assetURLs)
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(response)),
+            storage: StorageSpy(value: nil),
+            cache: cache
+        )
+        let result = await repository.bootstrapAfterAuthentication()
+        guard case let .success(snapshot) = result else { return XCTFail("bootstrap should succeed") }
+        XCTAssertEqual(snapshot.revision, "login-r1")
+        XCTAssertEqual(snapshot.catalogByType["CAT"]?.name, "CAT")
+    }
+
+    func testOnDemandLoaderDownloadsCacheMissAndReadsData() async {
+        let url = URL(string: "https://a/pet.svg")!
+        let expected = Data("<svg></svg>".utf8)
+        let cache = CacheSpy(downloadData: [url: expected])
+        let loaded = await RemotePetAssetLoader.data(for: url, cache: cache)
+        XCTAssertEqual(loaded, expected)
+        let attempts = await cache.attempts[url]
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testCanonicalizedTypeJoinTrimsAndUppercases() {
+        let snapshot = PetCatalogSnapshot(revision: "1", pets: [item(type: "  cat  ", levels: [1])])
+        let presentation = PetPresentation.resolve(petType: " Cat\n", petLevel: 1, snapshot: snapshot)
+        XCTAssertEqual(presentation.type, "CAT")
+        XCTAssertEqual(presentation.level?.level, 1)
+    }
+
+    @MainActor
+    func testSignUpLoginWaitsForCatalogBootstrapAndRejectsLoginFailure() async {
+        let response = PetCatalogResponse(revision: "signup", pets: [item(type: "CAT", levels: [1])])
+        let catalog = SignUpCatalogStub(response: response)
+        let successViewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
+            catalogRepository: catalog
+        )
+        let didSetSuccessPet = await successViewModel.updatePet(petType: .pinkCat)
+        XCTAssertTrue(didSetSuccessPet)
+        let loginSucceeded = await successViewModel.login()
+        let successSyncCount = await catalog.syncCount
+        XCTAssertTrue(loginSucceeded)
+        XCTAssertEqual(successSyncCount, 1)
+
+        let failedCatalog = SignUpCatalogStub(response: response)
+        let failureViewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(loginResult: .failure(.requestFailed("login failed"))),
+            catalogRepository: failedCatalog
+        )
+        let loginFailed = await failureViewModel.login()
+        let failedSyncCount = await failedCatalog.syncCount
+        XCTAssertFalse(loginFailed)
+        XCTAssertEqual(failedSyncCount, 0)
+
+        let bootstrapFailure = SignUpCatalogStub(result: .failure(.requestFailed("catalog failed")))
+        let bootstrapFailureViewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
+            catalogRepository: bootstrapFailure
+        )
+        let didSetFailurePet = await bootstrapFailureViewModel.updatePet(petType: .pinkCat)
+        XCTAssertTrue(didSetFailurePet)
+        let bootstrapFailed = await bootstrapFailureViewModel.login()
+        let bootstrapFailureSyncCount = await bootstrapFailure.syncCountValue()
+        XCTAssertFalse(bootstrapFailed)
+        XCTAssertEqual(bootstrapFailureSyncCount, 1)
+
+        let emptyBootstrap = SignUpCatalogStub(response: .init(revision: "empty", pets: []))
+        let emptyViewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
+            catalogRepository: emptyBootstrap
+        )
+        let didSetEmptyPet = await emptyViewModel.updatePet(petType: .pinkCat)
+        XCTAssertTrue(didSetEmptyPet)
+        let emptySucceeded = await emptyViewModel.login()
+        let emptySyncCount = await emptyBootstrap.syncCountValue()
+        XCTAssertFalse(emptySucceeded)
+        XCTAssertEqual(emptySyncCount, 1)
+    }
+
+    @MainActor
+    func testSignUpReadinessUsesSetMainPetInsteadOfStaleDefaults() async {
+        UserDefaultValue.petType = "DOG"
+        UserDefaultValue.level = 5
+        let response = PetCatalogResponse(revision: "signup", pets: [item(type: "CAT", levels: [1])])
+        let catalog = SignUpCatalogStub(response: response)
+        let viewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
+            catalogRepository: catalog
+        )
+
+        let didSetPet = await viewModel.updatePet(petType: .pinkCat)
+        let didLogin = await viewModel.login()
+        XCTAssertTrue(didSetPet)
+        XCTAssertTrue(didLogin)
+
+        let prepared = await catalog.preparedPet()
+        XCTAssertEqual(prepared?.type, "CAT")
+        XCTAssertEqual(prepared?.level, 1)
+    }
+
+    @MainActor
+    func testSplashBootstrapFailureStaysOnSplashAndRetryCanEnterMain() async {
+        let coordinator = AppCoordinator()
+        let snapshot = PetCatalogSnapshot(revision: "ready", pets: [item(type: "CAT", levels: [1])])
+        let catalog = RetryCatalogStub(snapshot: snapshot)
+        let viewModel = SplashViewModel(
+            coordinator: coordinator,
+            homeRepository: SplashHomeRepositoryStub(),
+            catalogRepository: catalog
+        )
+
+        await viewModel.performInitialSetup()
+        guard case .failed = viewModel.bootstrapState else { return XCTFail("failure state must be visible") }
+        XCTAssertEqual(coordinator.rootView, .splash)
+
+        await viewModel.retryInitialSetup()
+        await Task.yield()
+        XCTAssertEqual(viewModel.bootstrapState, .idle)
+        XCTAssertEqual(coordinator.rootView, .mainTab)
+        let prepareCount = await catalog.prepareCount
+        XCTAssertEqual(prepareCount, 2)
+    }
+
+    @MainActor
+    func testFriendCardBackgroundResolverUsesPublishedCatalogColor() async {
+        let store = PetCatalogStore()
+        let before = FriendCardCatalogResolver.presentation(petType: "CAT", petLevel: 1, snapshot: store.snapshot)
+        XCTAssertNil(before.colorCode)
+
+        let catalog = PetCatalogSnapshot(revision: "1", pets: [item(type: "CAT", color: "#123456", levels: [1])])
+        store.publish(catalog)
+        let after = FriendCardCatalogResolver.presentation(petType: "CAT", petLevel: 1, snapshot: store.snapshot)
+        XCTAssertEqual(after.colorCode, "#123456")
+    }
+
+    private func makeLoginData() -> LoginData {
+        .init(
+            accessToken: "access",
+            refreshToken: "refresh",
+            user: .init(
+                id: "user",
+                name: "name",
+                purposeCalorie: 100,
+                foodQuantity: 1,
+                toyQuantity: 1,
+                tickets: 0,
+                setting: .init(isAppPushOn: true)
+            ),
+            isOnboardingComplete: true
+        )
+    }
+
+    private func item(type: String, color: String = "#112233", levels: [Int], host: String = "a") -> PetCatalogItem {
+        .init(type: type, name: type, colorCode: color, displayOrder: 0, levels: levels.map {
+            .init(level: $0, imageUrl: "https://\(host)/\($0).svg", lottieDefaultUrl: "https://\(host)/\($0)d.json", lottiePlayEatUrl: "https://\(host)/\($0)p.json")
+        })
+    }
+}
+
+private struct NetworkStub: PetCatalogNetworking {
+    let result: Result<PetCatalogResponse, NetworkError>
+    func fetchCatalog() async -> Result<PetCatalogResponse, NetworkError> { result }
+}
+
+private actor SignUpCatalogStub: PetCatalogRepositoryProtocol {
+    let result: Result<PetCatalogSnapshot, NetworkError>
+    var syncCount = 0
+    var prepared: (type: String, level: Int)?
+    init(response: PetCatalogResponse) {
+        self.result = .success(.init(revision: response.revision, pets: response.pets))
+    }
+    init(result: Result<PetCatalogSnapshot, NetworkError>) { self.result = result }
+    func loadLocal() -> PetCatalogSnapshot { .empty }
+    func sync() -> Result<PetCatalogSnapshot, NetworkError> {
+        syncCount += 1
+        return result
+    }
+    func prepareForMain(petType: String, level: Int) -> Result<PetCatalogSnapshot, NetworkError> {
+        prepared = (petType, level)
+        syncCount += 1
+        return result
+    }
+    func preparedPet() -> (type: String, level: Int)? { prepared }
+    func syncCountValue() -> Int { syncCount }
+}
+
+private actor RetryCatalogStub: PetCatalogRepositoryProtocol {
+    let snapshot: PetCatalogSnapshot
+    var prepareCount = 0
+    init(snapshot: PetCatalogSnapshot) { self.snapshot = snapshot }
+    func loadLocal() -> PetCatalogSnapshot { .empty }
+    func sync() -> Result<PetCatalogSnapshot, NetworkError> { .success(snapshot) }
+    func prepareForMain(petType: String, level: Int) -> Result<PetCatalogSnapshot, NetworkError> {
+        prepareCount += 1
+        return prepareCount == 1
+            ? .failure(.requestFailed("temporary"))
+            : .success(snapshot)
+    }
+}
+
+private struct SplashHomeRepositoryStub: HomeRepositoryProtocol {
+    func getUserInfo() async -> Result<HomeUserInfo, NetworkError> {
+        .success(.init(id: "user", purposeCalorie: 100, foodQuantity: 1, toyQuantity: 1, tickets: 0))
+    }
+    func getMainPetInfo() async -> Result<MainPet, NetworkError> {
+        .success(.init(mainPet: .init(id: "pet", type: "CAT", level: 1, expPercent: 0)))
+    }
+    func getPetArchive() async -> Result<PetArchiveModel, NetworkError> { .failure(.requestFailed("unused")) }
+    func getSpecificPet(petId: String) async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func updateMainPet(petId: String) async -> Result<MainPet, NetworkError> { .failure(.requestFailed("unused")) }
+    func feedPet(petId: String) async -> Result<UserPetData, NetworkError> { .failure(.requestFailed("unused")) }
+    func playPet(petId: String) async -> Result<UserPetData, NetworkError> { .failure(.requestFailed("unused")) }
+    func addNewPet(petType: String) async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func addNewRandomPet() async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func addNewGachaRandomPet() async -> Result<Pet, NetworkError> { .failure(.requestFailed("unused")) }
+    func updateDailyKcal(calorie: Int) async -> Result<DailyUserData, NetworkError> { .failure(.requestFailed("unused")) }
+}
+
+private struct SignUpRepositoryStub: SignUpRepositoryProtocol {
+    let loginResult: Result<LoginData, NetworkError>
+    func update(name: String?, purposeCalorie: Int?) async -> Result<UserData, NetworkError> { .failure(.requestFailed("unused")) }
+    func getKakaoToken() -> String? { "token" }
+    func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError> { loginResult }
+    func addPet(petType: String) async -> Result<Pet, NetworkError> {
+        .success(.init(id: "new-pet", type: petType, level: 1, expPercent: 0))
+    }
+    func setMainPet(petID: String) async -> Result<MainPet, NetworkError> {
+        .success(.init(mainPet: .init(id: petID, type: "CAT", level: 1, expPercent: 0)))
+    }
+}
+
+private actor DelayedNetwork: PetCatalogNetworking {
+    let response: PetCatalogResponse
+    var callCount = 0
+    init(response: PetCatalogResponse) { self.response = response }
+    func fetchCatalog() async -> Result<PetCatalogResponse, NetworkError> {
+        callCount += 1
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        return .success(response)
+    }
+}
+
+private actor StorageSpy: PetCatalogStoring {
+    var value: PetCatalogResponse?
+    var saveCount = 0
+    init(value: PetCatalogResponse?) { self.value = value }
+    func load() -> PetCatalogResponse? { value }
+    func save(_ catalog: PetCatalogResponse) { value = catalog; saveCount += 1 }
+    func set(_ catalog: PetCatalogResponse) { value = catalog }
+}
+
+private actor CacheSpy: PetAssetCaching {
+    var existing = Set<URL>()
+    var downloaded = Set<URL>()
+    var failOnce = Set<URL>()
+    let alwaysFail: Set<URL>
+    var attempts: [URL: Int] = [:]
+    var storedData: [URL: Data]
+    let downloadData: [URL: Data]
+    init(existing: Set<URL> = [], failOnce: Set<URL> = [], alwaysFail: Set<URL> = [], downloadData: [URL: Data] = [:]) {
+        self.existing = existing
+        self.failOnce = failOnce
+        self.alwaysFail = alwaysFail
+        self.storedData = [:]
+        self.downloadData = downloadData
+    }
+    func contains(_ url: URL) -> Bool { existing.contains(url) }
+    func localURL(for url: URL) -> URL? { existing.contains(url) ? url : nil }
+    func data(for url: URL) -> Data? { storedData[url] }
+    func download(_ url: URL) -> URL? {
+        attempts[url, default: 0] += 1
+        if alwaysFail.contains(url) { return nil }
+        if failOnce.remove(url) != nil { return nil }
+        downloaded.insert(url)
+        existing.insert(url)
+        storedData[url] = downloadData[url]
+        return url
+    }
+    func invalidate(_ url: URL) { existing.remove(url) }
+}

--- a/DDanDDanTests/PetCatalogTests.swift
+++ b/DDanDDanTests/PetCatalogTests.swift
@@ -18,6 +18,56 @@ final class PetCatalogTests: XCTestCase {
         XCTAssertEqual(downloadCount, 6)
     }
 
+    func testFirstMainPreparationDownloadsOnlySelectedPetAssets() async {
+        let response = PetCatalogResponse(revision: "fresh", pets: [
+            item(type: "CAT", levels: [1, 2]),
+            item(type: "DOG", levels: [1, 2], host: "dog")
+        ])
+        let storage = StorageSpy(value: nil)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(response)),
+            storage: storage,
+            cache: cache
+        )
+
+        guard case .success = await repository.prepareForMain(petType: "CAT", level: 1) else {
+            return XCTFail("selected pet assets should prepare successfully")
+        }
+        let downloaded = await cache.downloaded
+        XCTAssertEqual(downloaded, response.pets[0].levels[0].assetURLs)
+        let stored = await storage.load()
+        XCTAssertEqual(stored?.revision, "fresh")
+    }
+
+    func testMainPreparationRejectsCatalogWithoutSelectedPet() async {
+        let response = PetCatalogResponse(revision: "fresh", pets: [item(type: "DOG", levels: [1])])
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(response)),
+            storage: StorageSpy(value: nil),
+            cache: CacheSpy()
+        )
+
+        guard case .failure = await repository.prepareForMain(petType: "CAT", level: 1) else {
+            return XCTFail("catalog without selected pet must fail bootstrap")
+        }
+    }
+
+    func testSameRevisionMainPreparationFailsWhenRequiredAssetCannotDownload() async {
+        let response = PetCatalogResponse(revision: "same", pets: [item(type: "CAT", levels: [1])])
+        let failedURL = response.pets[0].levels[0].imageURL!
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(response)),
+            storage: StorageSpy(value: response),
+            cache: CacheSpy(alwaysFail: [failedURL])
+        )
+
+        _ = await repository.loadLocal()
+        guard case .failure = await repository.sync() else {
+            return XCTFail("required asset failure must not report readiness")
+        }
+    }
+
     func testFreshCatalogAssetFailureBlocksSaveAndPublish() async {
         let response = PetCatalogResponse(revision: "fresh", pets: [item(type: "CAT", levels: [1])])
         let failedURL = URL(string: "https://a/1d.json")!
@@ -348,6 +398,24 @@ final class PetCatalogTests: XCTestCase {
         XCTAssertTrue(revisions.allSatisfy { $0 == "new" })
     }
 
+    func testFullSyncFollowingMainPreparationDownloadsRemainingAssets() async {
+        let response = PetCatalogResponse(revision: "new", pets: [item(type: "CAT", levels: [1, 2])])
+        let network = DelayedNetwork(response: response)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(network: network, storage: StorageSpy(value: nil), cache: cache)
+
+        let mainPreparation = Task {
+            await repository.prepareForMain(petType: "CAT", level: 1)
+        }
+        try? await Task.sleep(nanoseconds: 5_000_000)
+        let fullSync = await repository.sync()
+        _ = await mainPreparation.value
+
+        guard case .success = fullSync else { return XCTFail("full sync should follow selected asset sync") }
+        let downloaded = await cache.downloaded
+        XCTAssertEqual(downloaded, PetCatalogSnapshot(revision: response.revision, pets: response.pets).assetURLs)
+    }
+
     func testOlderResponseCannotOverwriteNewerLocalGeneration() async {
         let oldResponse = PetCatalogResponse(revision: "old-server", pets: [item(type: "OLD", levels: [1])])
         let newerLocal = PetCatalogResponse(revision: "new-local", pets: [item(type: "NEW", levels: [1])])
@@ -435,7 +503,9 @@ final class PetCatalogTests: XCTestCase {
         let catalog = SignUpCatalogStub(response: response)
         let successViewModel = SignUpViewModel(
             repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
-            catalogRepository: catalog
+            catalogRepository: catalog,
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: WatchSyncSpy()
         )
         let didSetSuccessPet = await successViewModel.updatePet(petType: .pinkCat)
         XCTAssertTrue(didSetSuccessPet)
@@ -447,7 +517,9 @@ final class PetCatalogTests: XCTestCase {
         let failedCatalog = SignUpCatalogStub(response: response)
         let failureViewModel = SignUpViewModel(
             repository: SignUpRepositoryStub(loginResult: .failure(.requestFailed("login failed"))),
-            catalogRepository: failedCatalog
+            catalogRepository: failedCatalog,
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: WatchSyncSpy()
         )
         let loginFailed = await failureViewModel.login()
         let failedSyncCount = await failedCatalog.syncCount
@@ -457,7 +529,9 @@ final class PetCatalogTests: XCTestCase {
         let bootstrapFailure = SignUpCatalogStub(result: .failure(.requestFailed("catalog failed")))
         let bootstrapFailureViewModel = SignUpViewModel(
             repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
-            catalogRepository: bootstrapFailure
+            catalogRepository: bootstrapFailure,
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: WatchSyncSpy()
         )
         let didSetFailurePet = await bootstrapFailureViewModel.updatePet(petType: .pinkCat)
         XCTAssertTrue(didSetFailurePet)
@@ -469,7 +543,9 @@ final class PetCatalogTests: XCTestCase {
         let emptyBootstrap = SignUpCatalogStub(response: .init(revision: "empty", pets: []))
         let emptyViewModel = SignUpViewModel(
             repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
-            catalogRepository: emptyBootstrap
+            catalogRepository: emptyBootstrap,
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: WatchSyncSpy()
         )
         let didSetEmptyPet = await emptyViewModel.updatePet(petType: .pinkCat)
         XCTAssertTrue(didSetEmptyPet)
@@ -493,7 +569,9 @@ final class PetCatalogTests: XCTestCase {
         let catalog = SignUpCatalogStub(response: response)
         let viewModel = SignUpViewModel(
             repository: SignUpRepositoryStub(loginResult: .success(makeLoginData())),
-            catalogRepository: catalog
+            catalogRepository: catalog,
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: WatchSyncSpy()
         )
 
         let didSetPet = await viewModel.updatePet(petType: .pinkCat)
@@ -504,6 +582,76 @@ final class PetCatalogTests: XCTestCase {
         let prepared = await catalog.preparedPet()
         XCTAssertEqual(prepared?.type, "CAT")
         XCTAssertEqual(prepared?.level, 1)
+    }
+
+    @MainActor
+    func testAppleSignUpUsesOriginalCredentialAndSyncsWatch() async {
+        let response = PetCatalogResponse(revision: "signup", pets: [item(type: "CAT", levels: [1])])
+        let watch = WatchSyncSpy()
+        let viewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(
+                loginResult: .success(makeLoginData()),
+                credential: .init(token: "apple-token", tokenType: "APPLE")
+            ),
+            catalogRepository: SignUpCatalogStub(response: response),
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: watch
+        )
+
+        let didSetPet = await viewModel.updatePet(petType: .pinkCat)
+        let didLogin = await viewModel.login()
+        XCTAssertTrue(didSetPet)
+        XCTAssertTrue(didLogin)
+        let watchSyncCount = await watch.syncCount
+        let watchPetType = await watch.lastPetType
+        XCTAssertEqual(watchSyncCount, 1)
+        XCTAssertEqual(watchPetType, "CAT")
+        XCTAssertEqual(viewModel.preparedUserInfo?.id, "user")
+    }
+
+    @MainActor
+    func testCompletedLoginCommitsUserPetCatalogAndWatchAtomically() async {
+        let coordinator = AppCoordinator()
+        let watch = WatchSyncSpy()
+        let response = PetCatalogResponse(revision: "login", pets: [item(type: "CAT", levels: [1])])
+        let viewModel = LoginViewModel(
+            repository: LoginRepositoryStub(),
+            appCoordinator: coordinator,
+            catalogRepository: SignUpCatalogStub(response: response),
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: watch
+        )
+
+        let didBootstrap = await viewModel.bootstrapCompletedUser()
+        XCTAssertTrue(didBootstrap)
+        XCTAssertEqual(coordinator.rootView, .mainTab)
+        XCTAssertEqual(coordinator.userInfo?.id, "user")
+        XCTAssertEqual(coordinator.petInfo?.mainPet.type, "CAT")
+        let watchSyncCount = await watch.syncCount
+        XCTAssertEqual(watchSyncCount, 1)
+    }
+
+    @MainActor
+    func testSignUpCalorieFailureDoesNotOverwriteLocalValue() async {
+        let original = UserDefaultValue.purposeKcal
+        defer { UserDefaultValue.purposeKcal = original }
+        UserDefaultValue.purposeKcal = 100
+        let viewModel = SignUpViewModel(
+            repository: SignUpRepositoryStub(
+                loginResult: .success(makeLoginData()),
+                updateResult: .failure(.requestFailed("update failed"))
+            ),
+            catalogRepository: SignUpCatalogStub(response: .init(revision: "unused", pets: [])),
+            homeRepository: SplashHomeRepositoryStub(),
+            watchSyncer: WatchSyncSpy()
+        )
+
+        let didUpdate = await viewModel.updateCalorie(calorie: 500)
+        XCTAssertFalse(didUpdate)
+        XCTAssertEqual(UserDefaultValue.purposeKcal, 100)
+        guard case .failed = viewModel.bootstrapState else {
+            return XCTFail("failure must remain visible")
+        }
     }
 
     @MainActor
@@ -626,14 +774,42 @@ private struct SplashHomeRepositoryStub: HomeRepositoryProtocol {
 
 private struct SignUpRepositoryStub: SignUpRepositoryProtocol {
     let loginResult: Result<LoginData, NetworkError>
-    func update(name: String?, purposeCalorie: Int?) async -> Result<UserData, NetworkError> { .failure(.requestFailed("unused")) }
-    func getKakaoToken() -> String? { "token" }
-    func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError> { loginResult }
+    var credential = LoginCredential(token: "token", tokenType: "KAKAO")
+    var updateResult: Result<UserData, NetworkError> = .failure(.requestFailed("unused"))
+    func update(name: String?, purposeCalorie: Int?) async -> Result<UserData, NetworkError> { updateResult }
+    func getLoginCredential() -> LoginCredential? { credential }
+    func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError> {
+        guard token == credential.token, tokenType == credential.tokenType else {
+            return .failure(.requestFailed("credential mismatch"))
+        }
+        return loginResult
+    }
     func addPet(petType: String) async -> Result<Pet, NetworkError> {
         .success(.init(id: "new-pet", type: petType, level: 1, expPercent: 0))
     }
     func setMainPet(petID: String) async -> Result<MainPet, NetworkError> {
         .success(.init(mainPet: .init(id: petID, type: "CAT", level: 1, expPercent: 0)))
+    }
+}
+
+private struct LoginRepositoryStub: LoginRepositoryProtocol {
+    func login(token: String, tokenType: String) async -> Result<LoginData, NetworkError> {
+        .failure(.requestFailed("unused"))
+    }
+}
+
+private actor WatchSyncSpy: WatchPetSyncing {
+    private(set) var syncCount = 0
+    private(set) var lastPetType: String?
+
+    func syncPet(
+        purposeKcal: Int,
+        petType: String,
+        level: Int,
+        presentation: PetPresentation
+    ) {
+        syncCount += 1
+        lastPetType = petType
     }
 }
 

--- a/DDanDDanTests/PetCatalogTests.swift
+++ b/DDanDDanTests/PetCatalogTests.swift
@@ -61,6 +61,43 @@ final class PetCatalogTests: XCTestCase {
         XCTAssertNil(stored)
     }
 
+    func testFreshCatalogAllowsAssetsSharedAcrossLevels() async {
+        let sharedImage = "https://a/shared.svg"
+        let levels = [
+            PetCatalogLevel(
+                level: 1,
+                imageUrl: sharedImage,
+                lottieDefaultUrl: "https://a/1-default.json",
+                lottiePlayEatUrl: "https://a/1-play.json"
+            ),
+            PetCatalogLevel(
+                level: 2,
+                imageUrl: sharedImage,
+                lottieDefaultUrl: "https://a/2-default.json",
+                lottiePlayEatUrl: "https://a/2-play.json"
+            )
+        ]
+        let response = PetCatalogResponse(
+            revision: "shared",
+            pets: [.init(type: "CAT", name: "cat", colorCode: "#112233", displayOrder: 0, levels: levels)]
+        )
+        let storage = StorageSpy(value: nil)
+        let cache = CacheSpy()
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(response)),
+            storage: storage,
+            cache: cache
+        )
+
+        guard case .success = await repository.sync() else {
+            return XCTFail("shared assets across levels should be valid")
+        }
+        let downloaded = await cache.downloaded
+        XCTAssertEqual(downloaded.count, 5)
+        let saveCount = await storage.saveCount
+        XCTAssertEqual(saveCount, 1)
+    }
+
     func testRevisionAssetFailurePreservesStoredCatalog() async {
         let old = PetCatalogResponse(revision: "old", pets: [item(type: "CAT", levels: [1], host: "old")])
         let new = PetCatalogResponse(revision: "new", pets: [item(type: "CAT", levels: [1], host: "new")])
@@ -94,6 +131,24 @@ final class PetCatalogTests: XCTestCase {
         }
         let downloaded = await cache.downloaded
         XCTAssertEqual(downloaded, local.pets[0].levels[1].assetURLs)
+    }
+
+    func testCachedLaunchSyncsWhenMainPetIsMissingLocally() async {
+        let local = PetCatalogResponse(revision: "local", pets: [item(type: "CAT", levels: [1])])
+        let remote = PetCatalogResponse(revision: "remote", pets: [item(type: "DOG", levels: [1])])
+        let storage = StorageSpy(value: local)
+        let repository = PetCatalogRepository(
+            network: NetworkStub(result: .success(remote)),
+            storage: storage,
+            cache: CacheSpy()
+        )
+
+        guard case let .success(snapshot) = await repository.prepareForMain(petType: "DOG", level: 1) else {
+            return XCTFail("missing local pet should recover through sync")
+        }
+        XCTAssertNotNil(snapshot.catalogByType["DOG"])
+        let stored = await storage.load()
+        XCTAssertEqual(stored?.revision, "remote")
     }
 
     @MainActor
@@ -259,7 +314,13 @@ final class PetCatalogTests: XCTestCase {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
-        let storage = PetCatalogStorage(fileURL: directory.appendingPathComponent("catalog.json"))
+        let suite = "pet-catalog-storage-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let storage = PetCatalogStorage(
+            fileURL: directory.appendingPathComponent("catalog.json"),
+            revisionStore: PetCatalogRevisionStore(defaults: defaults)
+        )
         let expected = PetCatalogResponse(revision: "r2", pets: [item(type: "CAT", levels: [1, 5])])
         try await storage.save(expected)
         let loaded = await storage.load()
@@ -420,6 +481,12 @@ final class PetCatalogTests: XCTestCase {
 
     @MainActor
     func testSignUpReadinessUsesSetMainPetInsteadOfStaleDefaults() async {
+        let originalPetType = UserDefaultValue.petType
+        let originalLevel = UserDefaultValue.level
+        defer {
+            UserDefaultValue.petType = originalPetType
+            UserDefaultValue.level = originalLevel
+        }
         UserDefaultValue.petType = "DOG"
         UserDefaultValue.level = 5
         let response = PetCatalogResponse(revision: "signup", pets: [item(type: "CAT", levels: [1])])

--- a/DdanDdan_Watch Watch App/Util/WatchConnectivityManager.swift
+++ b/DdanDdan_Watch Watch App/Util/WatchConnectivityManager.swift
@@ -54,11 +54,7 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
     }
 
     func session(_ session: WCSession, didReceive file: WCSessionFile) {
-        let latestIdentity = WatchPetSyncMetadata(
-            dictionary: session.receivedApplicationContext
-        )?.assetIdentity
         guard let metadata = file.metadata.flatMap(WatchPetSyncMetadata.init(dictionary:)),
-              latestIdentity == nil || latestIdentity == metadata.assetIdentity,
               let data = try? Data(contentsOf: file.fileURL),
               let svg = String(data: data, encoding: .utf8),
               svg.lowercased().contains("<svg"),
@@ -72,14 +68,10 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
             try? data.write(to: cacheURL, options: .atomic)
         }
         defaults?.set(metadata.assetIdentity, forKey: Self.cachedAssetIdentityKey)
-        persist(metadata)
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            if let latestIdentity = WatchPetSyncMetadata(
-                dictionary: session.receivedApplicationContext
-            )?.assetIdentity, latestIdentity != metadata.assetIdentity { return }
-            apply(metadata)
+            guard assetIdentity == metadata.assetIdentity else { return }
             petSVG = svg
         }
     }
@@ -92,7 +84,9 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
 
     private func apply(_ metadata: WatchPetSyncMetadata) {
         if assetIdentity != metadata.assetIdentity {
-            petSVG = nil
+            petSVG = cachedSVG(for: metadata.assetIdentity)
+        } else if petSVG == nil {
+            petSVG = cachedSVG(for: metadata.assetIdentity)
         }
         purposeKcal = Double(metadata.purposeKcal)
         petType = metadata.petType
@@ -109,11 +103,16 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
         guard let defaults,
               let metadata = WatchPetSyncMetadata(dictionary: defaults.dictionaryRepresentation()) else { return }
         apply(metadata)
-        guard defaults.string(forKey: Self.cachedAssetIdentityKey) == metadata.assetIdentity,
+    }
+
+    private func cachedSVG(for identity: String) -> String? {
+        guard defaults?.string(forKey: Self.cachedAssetIdentityKey) == identity,
               let cacheURL = cachedAssetURL(),
               let data = try? Data(contentsOf: cacheURL),
-              let svg = String(data: data, encoding: .utf8) else { return }
-        petSVG = svg
+              let svg = String(data: data, encoding: .utf8),
+              svg.lowercased().contains("<svg"),
+              svg.lowercased().contains("</svg>") else { return nil }
+        return svg
     }
 
     private func cachedAssetURL() -> URL? {

--- a/DdanDdan_Watch Watch App/Util/WatchConnectivityManager.swift
+++ b/DdanDdan_Watch Watch App/Util/WatchConnectivityManager.swift
@@ -5,19 +5,27 @@
 //  Created by 이지희 on 10/25/24.
 //
 
-import WatchConnectivity
+import Foundation
 import SwiftUI
+import WatchConnectivity
 
 /// 워치 앱에서의 WatchConnectivity 설정
 class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
     static let shared = WatchConnectivityManager()
+    private static let appGroup = "group.com.DdanDdan"
+    private static let cachedAssetIdentityKey = "watchPetCachedAssetIdentity"
     
     @Published var purposeKcal: Double = 0.0
     @Published var petType: String = ""
     @Published var level: Int = 0
+    @Published var colorCode: String = "#D0DAE4"
+    @Published var petSVG: String?
+    private var assetIdentity = ""
+    private let defaults = UserDefaults(suiteName: appGroup)
     
     override private init() {
         super.init()
+        restoreCachedState()
         if WCSession.isSupported() {
             WCSession.default.delegate = self
             WCSession.default.activate()
@@ -32,21 +40,86 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
     }
     
     /// 워치로 iPhone으로부터 메시지를 받았을 때 처리하는 메서드
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {    }
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        apply(dictionary: message)
+    }
     
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
         print("Received user info: \(userInfo)")
-        
-        DispatchQueue.main.async {
-            if let purposeKcal = userInfo["purposeKcal"] as? Double {
-                self.purposeKcal = purposeKcal
-            }
-            if let petType = userInfo["petType"] as? String {
-                self.petType = petType
-            }
-            if let level = userInfo["level"] as? Int {
-                self.level = level
-            }
+        apply(dictionary: userInfo)
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        apply(dictionary: applicationContext)
+    }
+
+    func session(_ session: WCSession, didReceive file: WCSessionFile) {
+        let latestIdentity = WatchPetSyncMetadata(
+            dictionary: session.receivedApplicationContext
+        )?.assetIdentity
+        guard let metadata = file.metadata.flatMap(WatchPetSyncMetadata.init(dictionary:)),
+              latestIdentity == nil || latestIdentity == metadata.assetIdentity,
+              let data = try? Data(contentsOf: file.fileURL),
+              let svg = String(data: data, encoding: .utf8),
+              svg.lowercased().contains("<svg"),
+              svg.lowercased().contains("</svg>") else { return }
+
+        if let cacheURL = cachedAssetURL() {
+            try? FileManager.default.createDirectory(
+                at: cacheURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? data.write(to: cacheURL, options: .atomic)
         }
+        defaults?.set(metadata.assetIdentity, forKey: Self.cachedAssetIdentityKey)
+        persist(metadata)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if let latestIdentity = WatchPetSyncMetadata(
+                dictionary: session.receivedApplicationContext
+            )?.assetIdentity, latestIdentity != metadata.assetIdentity { return }
+            apply(metadata)
+            petSVG = svg
+        }
+    }
+
+    private func apply(dictionary: [String: Any]) {
+        guard let metadata = WatchPetSyncMetadata(dictionary: dictionary) else { return }
+        persist(metadata)
+        DispatchQueue.main.async { [weak self] in self?.apply(metadata) }
+    }
+
+    private func apply(_ metadata: WatchPetSyncMetadata) {
+        if assetIdentity != metadata.assetIdentity {
+            petSVG = nil
+        }
+        purposeKcal = Double(metadata.purposeKcal)
+        petType = metadata.petType
+        level = metadata.level
+        colorCode = metadata.colorCode
+        assetIdentity = metadata.assetIdentity
+    }
+
+    private func persist(_ metadata: WatchPetSyncMetadata) {
+        metadata.dictionary.forEach { defaults?.set($0.value, forKey: $0.key) }
+    }
+
+    private func restoreCachedState() {
+        guard let defaults,
+              let metadata = WatchPetSyncMetadata(dictionary: defaults.dictionaryRepresentation()) else { return }
+        apply(metadata)
+        guard defaults.string(forKey: Self.cachedAssetIdentityKey) == metadata.assetIdentity,
+              let cacheURL = cachedAssetURL(),
+              let data = try? Data(contentsOf: cacheURL),
+              let svg = String(data: data, encoding: .utf8) else { return }
+        petSVG = svg
+    }
+
+    private func cachedAssetURL() -> URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: Self.appGroup)?
+            .appendingPathComponent("PetCatalog/Watch", isDirectory: true)
+            .appendingPathComponent("main-pet.svg")
     }
 }

--- a/DdanDdan_Watch Watch App/View/ContentView.swift
+++ b/DdanDdan_Watch Watch App/View/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SVGView
 
 struct ContentView: View {
     @State private var isTapped: Bool = false
@@ -38,10 +39,18 @@ struct ContentView: View {
     }
     
     var imageView: some View {
-        Image(viewModel.viewConfig?.0 ?? .blueEgg)
-            .resizable()
-            .scaledToFit()
-            .frame(width: 100, height: 100) 
+        Group {
+            if let petSVG = viewModel.petSVG {
+                SVGView(string: petSVG)
+                    .scaledToFit()
+            } else {
+                Image(viewModel.viewConfig?.0 ?? .blueEgg)
+                    .resizable()
+                    .scaledToFit()
+            }
+        }
+        .frame(width: 100, height: 100)
+        .accessibilityLabel("메인 펫")
     }
     
     var body: some View {

--- a/DdanDdan_Watch Watch App/View/WatchViewModel.swift
+++ b/DdanDdan_Watch Watch App/View/WatchViewModel.swift
@@ -15,6 +15,7 @@ final class WatchViewModel: ObservableObject {
     @Published var currentKcal: Int
     @Published var currentKcalProgress: Double = 0.0
     @Published var viewConfig: (ImageResource, Color)?
+    @Published var petSVG: String?
     @Published var showLoginAlert = false
     
     private let healthKitManager: HealthKitManager = .shared
@@ -48,9 +49,10 @@ final class WatchViewModel: ObservableObject {
         return currentKcal >= goalKcal ?? 0
     }
     
-    /// petType에 따른 UI 설정
-    public func configureUI(petType: PetType, level: Int) -> (ImageResource, Color) {
-        return (petType.image(for: level), petType.color)
+    /// 서버 카탈로그 색상과 번들 폴백 이미지로 UI를 설정한다.
+    public func configureUI(petType: String, level: Int, colorCode: String) -> (ImageResource, Color) {
+        let fallbackImage = PetType(rawValue: petType)?.image(for: level) ?? .blueEgg
+        return (fallbackImage, Color(hex: colorCode))
     }
     
     /// 도달률 계산
@@ -74,11 +76,29 @@ final class WatchViewModel: ObservableObject {
             
             // 데이터 통합 처리
             self.goalKcal = Int(purposeKcal)
-            if let petTypeEnum = PetType(rawValue: petType) {
-                self.viewConfig = self.configureUI(petType: petTypeEnum, level: level)
-            }
+            self.viewConfig = self.configureUI(
+                petType: petType,
+                level: level,
+                colorCode: self.watchConnectivityManager.colorCode
+            )
             self.updateProgress()
         }
         .store(in: &cancellables)
+
+        watchConnectivityManager.$colorCode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] colorCode in
+                guard let self else { return }
+                self.viewConfig = self.configureUI(
+                    petType: self.watchConnectivityManager.petType,
+                    level: self.watchConnectivityManager.level,
+                    colorCode: colorCode
+                )
+            }
+            .store(in: &cancellables)
+
+        watchConnectivityManager.$petSVG
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$petSVG)
     }
 }

--- a/DdanDdan_Watch Watch AppTests/DdanDdan_Watch_Watch_AppTests.swift
+++ b/DdanDdan_Watch Watch AppTests/DdanDdan_Watch_Watch_AppTests.swift
@@ -10,8 +10,16 @@ import Testing
 
 struct DdanDdan_Watch_Watch_AppTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func petSyncMetadataRoundTrip() {
+        let expected = WatchPetSyncMetadata(
+            purposeKcal: 500,
+            petType: "NEW_PET",
+            level: 3,
+            colorCode: "#123456",
+            assetIdentity: "NEW_PET|3|asset"
+        )
+
+        #expect(WatchPetSyncMetadata(dictionary: expected.dictionary) == expected)
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- 서버 카탈로그 DTO와 사용자 펫 type 기반 결합을 구현했습니다.
- revision 및 전체 카탈로그를 원자 저장하고 SVG/Lottie URL 디스크 캐시를 추가했습니다.
- 최초 실행 시 전체 에셋 준비 후 진입하며, 기존 캐시가 있으면 현재 펫 필수 에셋만 검증합니다.
- 새 에셋 로딩 중 기존 펫을 유지해 placeholder 깜빡임을 방지했습니다.
- login을 제외한 모든 /v1 요청에 X-Pet-Catalog-Version을 전송합니다.
- X-Pet-Catalog-Download-Required 응답을 처리하는 single-flight refresh coordinator를 추가했습니다.

## 캐시 및 동기화 정책
- 같은 revision은 정상 캐시를 유지하고 누락 파일만 복구합니다.
- revision 변경 시 변경되거나 누락된 URL만 다운로드합니다.
- 새 에셋 준비가 실패하면 기존 catalog revision을 유지합니다.
- catalog 응답은 refresh 재귀 호출에서 제외합니다.

## 검증
- iOS Simulator Debug build 성공
- PetCatalogTests 및 PetCatalogHeaderTests 총 42개 통과
- login revision 헤더 제외, reissue 포함, epoch fallback 검증
- 동시 download-required 응답 single-flight 검증
- fresh cache에서 SVG 30개와 Lottie JSON 60개 다운로드 확인

## 남은 확인
- 실제 배포 환경에서 CDN 장애 시 초기 진입 재시도 UX 확인
- 기존 Swift 6 concurrency 및 Firebase build script warning은 별도 범위입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈/친구/랭킹/보관함에서 카탈로그 기반 펫 색상·레벨을 더 일관되게 표시합니다.
  * 원격 펫 자산을 상황에 맞게 불러와 애니메이션/이미지/플레이스홀더를 자동 전환합니다.
  * 워치에서도 펫 SVG 및 메타데이터 동기화가 더 안정적으로 반영됩니다.
* **버그 수정**
  * 로그인/스플래시 초기화 실패 시 안내 메시지와 “다시 시도”가 노출되며 부트스트랩 흐름이 안정화됐습니다.
* **개선**
  * 펫 타입·레벨 변경 및 동기화 반영이 더 빠르고 정확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->